### PR TITLE
refactor(security): substitui UserDetailsImpl por Jwt nos controllers

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
@@ -9,6 +9,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import static org.springframework.security.config.Customizer.withDefaults;
 import com.Mybuddy.Myb.Security.JwtAuthConverter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
@@ -39,5 +41,10 @@ public class SecurityConfig {
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter)));
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AuthController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AuthController.java
@@ -1,19 +1,13 @@
 package com.Mybuddy.Myb.Controller;
 
-import com.Mybuddy.Myb.Payload.Request.LoginRequest;
 import com.Mybuddy.Myb.Payload.Request.SignupRequest;
-import com.Mybuddy.Myb.Payload.Response.JwtResponse;
 import com.Mybuddy.Myb.Payload.Response.MessageResponse;
-import com.Mybuddy.Myb.Security.jwt.UserDetailsImpl;
 import com.Mybuddy.Myb.Service.AuthService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -25,28 +19,13 @@ public class AuthController {
         this.authService = authService;
     }
 
-    @PostMapping("/login")
-    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
-        Authentication authentication = authService.authenticateUser(loginRequest);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        String jwt = authService.generateJwtToken(authentication);
-
-        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
-
-        List<String> roles = userDetails.getAuthorities().stream()
-                .map(item -> item.getAuthority())
-                .collect(Collectors.toList());
-
-        return ResponseEntity.ok(new JwtResponse(
-                jwt,
-                userDetails.getId(),
-                userDetails.getUsername(),
-                userDetails.getEmail(),
-                roles,
-                userDetails.getOrganizacaoId()));
+    // TODO MY-105: endpoint /me para retornar dados do usuário autenticado via Keycloak
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal Jwt jwt) {
+        return ResponseEntity.ok(new MessageResponse("Usuário: " + jwt.getClaimAsString("preferred_username")));
     }
 
+    // TODO MY-110: avaliar se cadastro será via Keycloak Admin API
     @PostMapping("/cadastro")
     public ResponseEntity<?> registerUser(@Valid @RequestBody SignupRequest signUpRequest) {
         try {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PetController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PetController.java
@@ -2,7 +2,6 @@ package com.Mybuddy.Myb.Controller;
 
 import com.Mybuddy.Myb.DTO.PetRequestDTO;
 import com.Mybuddy.Myb.DTO.PetResponse;
-import com.Mybuddy.Myb.Security.jwt.UserDetailsImpl;
 import com.Mybuddy.Myb.Service.FotoPetService;
 import com.Mybuddy.Myb.Service.PetFiltro;
 import com.Mybuddy.Myb.Service.PetService;
@@ -16,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -105,7 +105,7 @@ public class PetController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN') or (hasRole('ONG') and @petService.isPetOwnedByCurrentUser(#id, authentication.principal.organizacaoId))")
+    @PreAuthorize("hasRole('ADMIN') or hasRole('ONG')")
     public ResponseEntity<PetResponse> atualizar(@PathVariable Long id, @Valid @RequestBody PetRequestDTO petRequestDTO) {
         log.info("Requisição para atualizar pet ID {}: {}", id, petRequestDTO.getNome());
         return ResponseEntity.ok(petService.atualizarPet(id, petRequestDTO));
@@ -121,14 +121,12 @@ public class PetController {
 
     @GetMapping("/organizacao/{organizacaoId}")
     @PreAuthorize("hasRole('ONG') or hasRole('ADMIN')")
-    public ResponseEntity<List<PetResponse>> getPetsByOrganizacao(@PathVariable Long organizacaoId,
-                                                                  @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        if (userDetails.getOrganizacaoId() != null && !userDetails.getOrganizacaoId().equals(organizacaoId) &&
-                !userDetails.getAuthorities().stream().anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"))) {
-            log.warn("Tentativa de acesso não autorizado aos pets da organização {} pelo usuário {}", organizacaoId, userDetails.getEmail());
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        }
-        log.info("Buscando pets da organização por ID: {}", organizacaoId);
+    public ResponseEntity<List<PetResponse>> getPetsByOrganizacao(
+            @PathVariable Long organizacaoId,
+            @AuthenticationPrincipal Jwt jwt) {
+        String keycloakId = jwt.getSubject();
+        log.info("Buscando pets da organização por ID: {} - solicitado por: {}", organizacaoId, keycloakId);
+        // TODO MY-110: validar se ONG pertence ao organizacaoId após sincronização
         return ResponseEntity.ok(petService.buscarPetsPorOrganizacaoId(organizacaoId));
     }
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/UsuarioController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/UsuarioController.java
@@ -1,13 +1,12 @@
 package com.Mybuddy.Myb.Controller;
 
 import com.Mybuddy.Myb.Model.Usuario;
-import com.Mybuddy.Myb.Security.jwt.UserDetailsImpl;
 import com.Mybuddy.Myb.Service.UsuarioService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -40,12 +39,10 @@ public class UsuarioController {
 
     @GetMapping("/meu-perfil")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<Usuario> getMeuPerfil() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
-        return usuarioService.buscarUsuarioPorId(userDetails.getId())
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+    public ResponseEntity<Usuario> getMeuPerfil(@AuthenticationPrincipal Jwt jwt) {
+        String keycloakId = jwt.getSubject();
+        // TODO MY-110: buscar usuário pelo keycloakId após sincronização
+        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
     }
 
     @GetMapping("/{id}")
@@ -57,8 +54,9 @@ public class UsuarioController {
     }
 
     @PutMapping("/{id}")
-    @PreAuthorize("hasRole('ADMIN') or (#id == authentication.principal.id)")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Usuario> atualizarUsuario(@PathVariable Long id, @RequestBody Usuario dadosUsuario) {
+        // TODO MY-110: permitir que o próprio usuário atualize após sincronização do keycloakId
         try {
             return ResponseEntity.ok(usuarioService.atualizarUsuario(id, dadosUsuario));
         } catch (IllegalStateException e) {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Security/jwt/AuthTokenFilter.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Security/jwt/AuthTokenFilter.java
@@ -10,12 +10,11 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
-@Component
+
 public class AuthTokenFilter extends OncePerRequestFilter {
 
     private static final Logger log = LoggerFactory.getLogger(AuthTokenFilter.class);

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Security/jwt/UserDetailsServiceImpl.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Security/jwt/UserDetailsServiceImpl.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 // Garante que a operação seja executada dentro de uma transação do banco
 
-@Service
+
 // Indica que esta classe é um serviço Spring, responsável por lógica de negócios relacionada a usuários
 public class UserDetailsServiceImpl implements UserDetailsService {
     // Implementa UserDetailsService, necessário para autenticação com Spring Security

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/AuthService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/AuthService.java
@@ -1,101 +1,61 @@
 package com.Mybuddy.Myb.Service;
 
-import com.Mybuddy.Myb.Exception.ConflictException; // Adicione esta importação
-import com.Mybuddy.Myb.Exception.ResourceNotFoundException; // Adicione esta importação
+import com.Mybuddy.Myb.Exception.ConflictException;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
 import com.Mybuddy.Myb.Model.Organizacao;
 import com.Mybuddy.Myb.Model.Usuario;
-import com.Mybuddy.Myb.Payload.Request.LoginRequest;
 import com.Mybuddy.Myb.Payload.Request.SignupRequest;
-import com.Mybuddy.Myb.Payload.Response.JwtResponse; // Para caso a autenticação venha para cá
 import com.Mybuddy.Myb.Repository.RoleRepository;
 import com.Mybuddy.Myb.Repository.UsuarioRepository;
 import com.Mybuddy.Myb.Security.ERole;
 import com.Mybuddy.Myb.Security.Role;
-import com.Mybuddy.Myb.Security.jwt.JwtUtils;
-import com.Mybuddy.Myb.Security.jwt.UserDetailsImpl;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.context.SecurityContextHolder; // Para manter o contexto de segurança
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional; // Importante para transações
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 public class AuthService {
 
-    private final AuthenticationManager authenticationManager;
-    private final UsuarioRepository usuarioRepository; // Renomeado para usuarioRepository
+    private final UsuarioRepository usuarioRepository;
     private final RoleRepository roleRepository;
     private final PasswordEncoder encoder;
-    private final JwtUtils jwtUtils;
-    private final OrganizacaoService organizacaoService; // Injeta o OrganizacaoService
+    private final OrganizacaoService organizacaoService;
 
-    @Autowired // @Autowired no construtor é opcional a partir do Spring 4.3, mas é boa prática para clareza
-    public AuthService(AuthenticationManager authenticationManager, UsuarioRepository usuarioRepository,
-                       RoleRepository roleRepository, PasswordEncoder encoder, JwtUtils jwtUtils,
+    public AuthService(UsuarioRepository usuarioRepository,
+                       RoleRepository roleRepository,
+                       PasswordEncoder encoder,
                        OrganizacaoService organizacaoService) {
-        this.authenticationManager = authenticationManager;
         this.usuarioRepository = usuarioRepository;
         this.roleRepository = roleRepository;
         this.encoder = encoder;
-        this.jwtUtils = jwtUtils;
         this.organizacaoService = organizacaoService;
     }
 
-    /**
-     * Autentica um usuário e retorna o objeto Authentication.
-     * Mantido aqui, mas também poderia retornar JwtResponse diretamente se preferir.
-     */
-    public Authentication authenticateUser(LoginRequest loginRequest) {
-        return authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword()));
-    }
-
-    /**
-     * Gera um token JWT para a autenticação fornecida.
-     */
-    public String generateJwtToken(Authentication authentication) {
-        return jwtUtils.generateJwtToken(authentication);
-    }
-
-    /**
-     * Lógica principal para registrar um novo usuário, incluindo a criação/associação de ONGs.
-     * @param signUpRequest DTO com os dados de registro.
-     * @throws ConflictException Se o e-mail ou CNPJ da ONG já estiverem em uso.
-     * @throws RuntimeException Para erros de role não encontrada ou campos obrigatórios ausentes.
-     */
-    @Transactional // Garante que a criação da ONG e do usuário sejam uma transação atômica
+    // TODO MY-110: avaliar migração do cadastro para Keycloak Admin API
+    @Transactional
     public void registerUser(SignupRequest signUpRequest) {
-        // 1. Validação de e-mail de usuário existente
         if (usuarioRepository.existsByEmail(signUpRequest.getEmail())) {
             throw new ConflictException("Erro: O e-mail já está em uso!");
         }
 
-        // Opcional: Validação de telefone de usuário existente
         if (signUpRequest.getTelefone() != null && usuarioRepository.existsByTelefone(signUpRequest.getTelefone())) {
             throw new ConflictException("Erro: O telefone já está em uso!");
         }
 
-        Set<String> strRoles = signUpRequest.getRoles(); // Agora é getRoles()
+        Set<String> strRoles = signUpRequest.getRoles();
         Set<Role> roles = new HashSet<>();
-        Organizacao organizacaoAssociada = null; // Inicializada como null
+        Organizacao organizacaoAssociada = null;
 
-        // 2. Processamento das Roles e Lógica da ONG
         if (strRoles == null || strRoles.isEmpty()) {
             Role adotanteRole = roleRepository.findByName(ERole.ROLE_ADOTANTE)
                     .orElseThrow(() -> new ResourceNotFoundException("Erro: Role ADOTANTE não encontrada."));
             roles.add(adotanteRole);
         } else {
             for (String roleName : strRoles) {
-                switch (roleName.toUpperCase()) { // Convertendo para maiúsculas para comparar com ERole
+                switch (roleName.toUpperCase()) {
                     case "ADMIN":
                         Role adminRole = roleRepository.findByName(ERole.ROLE_ADMIN)
                                 .orElseThrow(() -> new ResourceNotFoundException("Erro: Role ADMIN não encontrada."));
@@ -107,29 +67,18 @@ public class AuthService {
                                 .orElseThrow(() -> new ResourceNotFoundException("Erro: Role ONG não encontrada."));
                         roles.add(ongRole);
 
-                        // --- Lógica de Criação da Organização para a role ONG ---
-                        // Validações para campos obrigatórios da ONG
-                        if (signUpRequest.getOrganizacaoCnpj() == null || signUpRequest.getOrganizacaoCnpj().trim().isEmpty()) {
+                        if (signUpRequest.getOrganizacaoCnpj() == null || signUpRequest.getOrganizacaoCnpj().trim().isEmpty())
                             throw new RuntimeException("O CNPJ da organização é obrigatório para a role ONG.");
-                        }
-                        if (signUpRequest.getOrganizacaoNomeFantasia() == null || signUpRequest.getOrganizacaoNomeFantasia().trim().isEmpty()) {
+                        if (signUpRequest.getOrganizacaoNomeFantasia() == null || signUpRequest.getOrganizacaoNomeFantasia().trim().isEmpty())
                             throw new RuntimeException("O Nome Fantasia da organização é obrigatório para a role ONG.");
-                        }
-                        if (signUpRequest.getOrganizacaoEmailContato() == null || signUpRequest.getOrganizacaoEmailContato().trim().isEmpty()) {
+                        if (signUpRequest.getOrganizacaoEmailContato() == null || signUpRequest.getOrganizacaoEmailContato().trim().isEmpty())
                             throw new RuntimeException("O E-mail de Contato da organização é obrigatório para a role ONG.");
-                        }
-                        if (signUpRequest.getOrganizacaoEndereco() == null || signUpRequest.getOrganizacaoEndereco().trim().isEmpty()) {
+                        if (signUpRequest.getOrganizacaoEndereco() == null || signUpRequest.getOrganizacaoEndereco().trim().isEmpty())
                             throw new RuntimeException("O Endereço da organização é obrigatório para a role ONG.");
-                        }
 
-                        // Verifica se já existe uma ONG com o CNPJ ou Email de Contato (usando o serviço de ONG)
-                        if (organizacaoService.existeOrganizacaoPorCnpj(signUpRequest.getOrganizacaoCnpj())) {
+                        if (organizacaoService.existeOrganizacaoPorCnpj(signUpRequest.getOrganizacaoCnpj()))
                             throw new ConflictException("Já existe uma organização com o CNPJ: " + signUpRequest.getOrganizacaoCnpj());
-                        }
-                        // O OrganizacaoService.criarOrganizacao já verifica duplicidade de emailContato
-                        // então não precisamos duplicar a validação aqui para o email da ONG.
 
-                        // Cria a nova entidade Organizacao
                         Organizacao novaOrganizacao = new Organizacao();
                         novaOrganizacao.setCnpj(signUpRequest.getOrganizacaoCnpj());
                         novaOrganizacao.setNomeFantasia(signUpRequest.getOrganizacaoNomeFantasia());
@@ -139,7 +88,6 @@ public class AuthService {
                         novaOrganizacao.setDescricao(signUpRequest.getOrganizacaoDescricao());
                         novaOrganizacao.setWebsite(signUpRequest.getOrganizacaoWebsite());
 
-                        // Salva a ONG usando o OrganizacaoService
                         organizacaoAssociada = organizacaoService.criarOrganizacao(novaOrganizacao);
                         break;
 
@@ -155,16 +103,14 @@ public class AuthService {
             }
         }
 
-        // 3. Cria e Salva o Usuário
         Usuario user = new Usuario(
                 signUpRequest.getNome(),
                 signUpRequest.getEmail(),
                 signUpRequest.getTelefone(),
                 encoder.encode(signUpRequest.getPassword())
         );
-        user.setOrganizacao(organizacaoAssociada); // Associa a ONG (será null para Adotante/Admin)
-        user.setRoles(roles); // Atribui as roles
-
-        usuarioRepository.save(user); // Salva o usuário no banco
+        user.setOrganizacao(organizacaoAssociada);
+        user.setRoles(roles);
+        usuarioRepository.save(user);
     }
 }


### PR DESCRIPTION
## Task Jira
- **Card:** [MY-103](https://ederpontes2014.atlassian.net/browse/MY-103)
- **Tipo:** Refactor

---
## O que foi feito?
Refatoração dos controllers e camada de segurança para remover dependência do JWT manual legado (`UserDetailsImpl`, `AuthTokenFilter`, `JwtUtils`) e integrar com o Spring Security OAuth2 + Keycloak.

Controllers refatorados:
- `PetController` — removido `UserDetailsImpl`, adicionado `@AuthenticationPrincipal Jwt jwt`
- `AuthController` — removido endpoint `/login` (responsabilidade migrada para Keycloak), adicionado `/me` provisório
- `UsuarioController` — removido `UserDetailsImpl`, `/meu-perfil` e `PUT /{id}` marcados com TODO MY-110

Camada de segurança:
- `AuthService` — removidos `AuthenticationManager`, `JwtUtils`, `authenticateUser` e `generateJwtToken`
- `AuthTokenFilter` — removido `@Component` para evitar conflito com o filter chain do OAuth2
- `UserDetailsServiceImpl` — removido `@Service` para evitar registro de `AuthenticationManager` paralelo
- `PasswordEncoder` — movido para bean no `SecurityConfig`

---
## Escopo das mudanças
- [x] `backend` — Java / Spring Boot

---
## Checklist de Testes
- [x] Testei localmente e o comportamento está conforme esperado
- [x] Não há erros ou warnings novos no console
- [x] Validei endpoint sem token → `401`
- [x] Validei endpoint com token USER → `200`
- [x] Validei endpoint restrito a ONG/ADMIN com role correta → `201`
- [x] Validei endpoint restrito a ONG/ADMIN sem role → `403`
- [ ] Testes automatizados foram criados ou atualizados (MY-112 pendente)

---
## Checklist de Code Review
- [x] O código segue os padrões e convenções do projeto
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Dados sensíveis não estão expostos
- [x] TODOs presentes são intencionais e rastreados (MY-110)

---
## Notas para o Revisor
- `InteresseAdocaoController` ainda referencia `UserDetailsImpl` — bloqueado pela MY-110 (sincronização usuário Keycloak x banco)
- O endpoint `/login` foi removido pois com Keycloak a autenticação ocorre diretamente no servidor de identidade
- `@PutMapping("/{id}")` no `UsuarioController` simplificado para `hasRole('ADMIN')` temporariamente até MY-110
- `@Component` removido do `AuthTokenFilter` e `@Service` removido do `UserDetailsServiceImpl` para evitar conflito com o filter chain do OAuth2

---
## Como testar
1. Subir containers: `docker compose up -d`
2. Acessar Keycloak Admin Console em `http://localhost:8080/admin` e garantir que o usuário de teste tem a role desejada
3. Obter token: `curl -X POST http://localhost:8080/realms/mybuddy/protocol/openid-connect/token -d "grant_type=password&client_id=mybuddy-frontend&username=SEU_USUARIO&password=SUA_SENHA"`
4. Testar sem token: `curl http://localhost:8081/api/pets` → esperado `401`
5. Testar com token USER: `curl http://localhost:8081/api/pets -H "Authorization: Bearer TOKEN"` → esperado `200`
6. Testar POST `/api/pets` com role ONG → esperado `201`
7. Testar POST `/api/pets` sem role ONG → esperado `403`

[MY-103]: https://ederpontes2014.atlassian.net/browse/MY-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ