### PR TITLE
feat(auth): implementa sincronização de usuário Keycloak com banco [MY-110]

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/InteresseAdocaoController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/InteresseAdocaoController.java
@@ -3,8 +3,9 @@ package com.Mybuddy.Myb.Controller;
 import com.Mybuddy.Myb.DTO.AtualizarStatusRequest;
 import com.Mybuddy.Myb.DTO.InteresseResponse;
 import com.Mybuddy.Myb.DTO.RegistrarInteresseRequest;
-import com.Mybuddy.Myb.Security.jwt.UserDetailsImpl;
+import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Service.InteresseAdocaoService;
+import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,39 +13,33 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-
 
 @RestController
 @RequestMapping("/api")
 public class InteresseAdocaoController {
 
-    private static final Logger logger = LoggerFactory.getLogger(OrganizacaoController.class);
+    private static final Logger logger = LoggerFactory.getLogger(InteresseAdocaoController.class);
 
     private final InteresseAdocaoService service;
+    private final KeycloakUserSyncService keycloakUserSyncService;
 
-    public InteresseAdocaoController(InteresseAdocaoService service) {
+    public InteresseAdocaoController(InteresseAdocaoService service, KeycloakUserSyncService keycloakUserSyncService) {
         this.service = service;
+        this.keycloakUserSyncService = keycloakUserSyncService;
     }
 
     @PostMapping("/interesses")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<InteresseResponse> manifestarInteresse(
             @RequestBody @Valid RegistrarInteresseRequest req,
-            @AuthenticationPrincipal UserDetailsImpl userDetails
-    ) {
-        logger.debug("manifestarInteresse: MÉTODO ACESSADO!");
-        if (userDetails == null) {
-            logger.error("ERRO CRÍTICO (manifestarInteresse): userDetails é null!");
-            throw new IllegalStateException("Detalhes do usuário autenticado não disponíveis.");
-        }
-        logger.debug("manifestarInteresse: Usuario ID recuperado: {}", userDetails.getId());
-        logger.debug("manifestarInteresse: Usuario Email recuperado: {}", userDetails.getEmail());
-
-        Long usuarioId = userDetails.getId();
-        var resp = service.manifestarInteresse(usuarioId, req.petId(), req.mensagem());
+            @AuthenticationPrincipal Jwt jwt) {
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        logger.debug("manifestarInteresse: Usuario ID: {}, Email: {}", usuario.getId(), usuario.getEmail());
+        var resp = service.manifestarInteresse(usuario.getId(), req.petId(), req.mensagem());
         return ResponseEntity.status(HttpStatus.CREATED).body(resp);
     }
 
@@ -52,8 +47,7 @@ public class InteresseAdocaoController {
     @PreAuthorize("hasAnyRole('ADMIN','ONG')")
     public ResponseEntity<InteresseResponse> atualizarStatus(
             @PathVariable Long id,
-            @RequestBody @Valid AtualizarStatusRequest req
-    ) {
+            @RequestBody @Valid AtualizarStatusRequest req) {
         logger.debug("atualizarStatus: MÉTODO ACESSADO!");
         var resp = service.atualizarStatus(id, req.status());
         return ResponseEntity.ok(resp);
@@ -62,13 +56,9 @@ public class InteresseAdocaoController {
     @GetMapping("/usuarios/me/interesses")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<List<InteresseResponse>> listarMeusInteresses(
-            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        if (userDetails == null) {
-            throw new IllegalStateException("Detalhes do usuário autenticado não disponíveis.");
-        }
-
-        Long usuarioId = userDetails.getId();
-        var resp = service.listarPorUsuario(usuarioId);
+            @AuthenticationPrincipal Jwt jwt) {
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        var resp = service.listarPorUsuario(usuario.getId());
         return ResponseEntity.ok(resp);
     }
 
@@ -82,15 +72,13 @@ public class InteresseAdocaoController {
     @GetMapping("/ongs/me/interesses")
     @PreAuthorize("hasRole('ONG')")
     public ResponseEntity<List<InteresseResponse>> listarInteressesDaMinhaOng(
-            @AuthenticationPrincipal UserDetailsImpl userDetails
-    ) {
-        if (userDetails == null) {
-            throw new IllegalStateException("Detalhes do usuário autenticado não disponíveis.");
+            @AuthenticationPrincipal Jwt jwt) {
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        if (usuario.getOrganizacao() == null) {
+            throw new IllegalStateException("Usuário ONG não possui organização associada.");
         }
-        logger.debug("listarInteressesDaMinhaOng: ONG Usuario ID recuperado: {}", userDetails.getId());
-        logger.debug("listarInteressesDaMinhaOng: ONG Organizacao ID recuperado: {}", userDetails.getOrganizacaoId());
-
-        Long organizacaoId = userDetails.getOrganizacaoId();
+        Long organizacaoId = usuario.getOrganizacao().getId();
+        logger.debug("listarInteressesDaMinhaOng: ONG Organizacao ID: {}", organizacaoId);
         var resp = service.listarInteressesPorOrganizacao(organizacaoId);
         return ResponseEntity.ok(resp);
     }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/UsuarioController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/UsuarioController.java
@@ -1,6 +1,7 @@
 package com.Mybuddy.Myb.Controller;
 
 import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
 import com.Mybuddy.Myb.Service.UsuarioService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +17,11 @@ import java.util.List;
 public class UsuarioController {
 
     private final UsuarioService usuarioService;
+    private final KeycloakUserSyncService keycloakUserSyncService;
 
-    public UsuarioController(UsuarioService usuarioService) {
+    public UsuarioController(UsuarioService usuarioService, KeycloakUserSyncService keycloakUserSyncService) {
         this.usuarioService = usuarioService;
+        this.keycloakUserSyncService = keycloakUserSyncService;
     }
 
     @PostMapping
@@ -40,9 +43,8 @@ public class UsuarioController {
     @GetMapping("/meu-perfil")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<Usuario> getMeuPerfil(@AuthenticationPrincipal Jwt jwt) {
-        String keycloakId = jwt.getSubject();
-        // TODO MY-110: buscar usuário pelo keycloakId após sincronização
-        return ResponseEntity.status(HttpStatus.NOT_IMPLEMENTED).build();
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(usuario);
     }
 
     @GetMapping("/{id}")
@@ -56,7 +58,6 @@ public class UsuarioController {
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Usuario> atualizarUsuario(@PathVariable Long id, @RequestBody Usuario dadosUsuario) {
-        // TODO MY-110: permitir que o próprio usuário atualize após sincronização do keycloakId
         try {
             return ResponseEntity.ok(usuarioService.atualizarUsuario(id, dadosUsuario));
         } catch (IllegalStateException e) {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Usuario.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Usuario.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.security.Key;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -39,6 +40,9 @@ public class Usuario {
     @JsonBackReference
     @ToString.Exclude
     private Organizacao organizacao;
+
+    @Column(name = "Keycloak_id", unique=true)
+    private String keycloakId;
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(name = "user_roles",

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/UsuarioRepository.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/UsuarioRepository.java
@@ -11,4 +11,7 @@ public interface UsuarioRepository extends JpaRepository <Usuario, Long> {
     Optional<Usuario> findByEmail(String email);
     Boolean existsByEmail(String email);
     Boolean existsByTelefone(String telefone);
+
+    Optional<Usuario> findByKeycloakId(String keycloakId);
+    Boolean existsByKeycloakId(String keycloakId);
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/KeycloakUserSyncService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/KeycloakUserSyncService.java
@@ -1,0 +1,36 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Repository.UsuarioRepository;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class KeycloakUserSyncService {
+
+    private final UsuarioRepository usuarioRepository;
+
+    public KeycloakUserSyncService(UsuarioRepository usuarioRepository) {
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    @Transactional
+    public Usuario syncUsuario(Jwt jwt) {
+        String keycloakId = jwt.getSubject();
+
+        return usuarioRepository.findByKeycloakId(keycloakId)
+                .orElseGet(() -> criarUsuarioDoKeycloak(jwt));
+    }
+
+    private Usuario criarUsuarioDoKeycloak(Jwt jwt) {
+        Usuario usuario = new Usuario();
+        usuario.setKeycloakId(jwt.getSubject());
+        usuario.setEmail(jwt.getClaimAsString("email"));
+        usuario.setNome(jwt.getClaimAsString("name") != null
+                ? jwt.getClaimAsString("name")
+                : jwt.getClaimAsString("preferred_username"));
+        usuario.setPassword("KEYCLOAK_MANAGED");
+        return usuarioRepository.save(usuario);
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/UsuarioService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/UsuarioService.java
@@ -13,6 +13,7 @@ import java.util.Optional; // Importa a classe Optional para lidar com resultado
 @Service
 public class UsuarioService { // Declara a classe de serviço para Usuários.
 
+    public static final String KeycloakUserSyncService = null;
     private final UsuarioRepository usuarioRepository;
 
     public UsuarioService(UsuarioRepository usuarioRepository) {


### PR DESCRIPTION
## Task Jira
- **Card:** [MY-110](https://ederpontes2014.atlassian.net/browse/MY-110)
- **Tipo:** Feature

---
## O que foi feito?
Implementa sincronização automática entre o usuário autenticado via Keycloak e a entidade `Usuario` do banco de dados.

Mudanças realizadas:
- `Usuario` — adicionado campo `keycloakId` (`unique`, nullable)
- `UsuarioRepository` — adicionados métodos `findByKeycloakId` e `existsByKeycloakId`
- `KeycloakUserSyncService` — novo service que busca o usuário pelo `sub` do JWT ou cria automaticamente caso não exista
- `UsuarioController` — endpoint `/meu-perfil` atualizado para usar `syncUsuario(jwt)`
- `InteresseAdocaoController` — endpoints que dependiam de `UserDetailsImpl` refatorados para usar `syncUsuario(jwt)`

---
## Escopo das mudanças
- [x] `backend` — Java / Spring Boot
- [x] `db` — schema atualizado com campo `keycloak_id` na tabela `users`

---
## Checklist de Testes
- [x] Testei localmente e o comportamento está conforme esperado
- [x] GET `/api/usuarios/meu-perfil` com token Keycloak → retorna usuário sincronizado com `keycloakId` preenchido
- [x] Segundo acesso com o mesmo token → retorna o mesmo usuário sem duplicar
- [x] Não há erros ou warnings novos no console
- [ ] Testes automatizados foram criados ou atualizados (MY-112 pendente)

---
## Checklist de Code Review
- [x] O código segue os padrões e convenções do projeto
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada
- [x] Dados sensíveis não estão expostos
- [x] `password` definido como `KEYCLOAK_MANAGED` para usuários criados via Keycloak

---
## Notas para o Revisor
- O campo `keycloakId` é nullable para manter compatibilidade com usuários criados antes da integração com Keycloak
- A sincronização é feita a cada requisição autenticada — futuramente pode ser otimizada com cache
- `InteresseAdocaoController` agora usa `usuario.getOrganizacao().getId()` para listar interesses da ONG — requer que o usuário ONG tenha organização associada no banco

---
## Como testar
1. Subir containers: `docker compose up -d`
2. Obter token: `curl -X POST http://localhost:8080/realms/mybuddy/protocol/openid-connect/token -d "grant_type=password&client_id=mybuddy-frontend&username=davi&password=SUA_SENHA"`
3. GET `http://localhost:8081/api/usuarios/meu-perfil` com `Authorization: Bearer TOKEN`
4. Verificar que o retorno contém `keycloakId` preenchido com o `sub` do token
5. Repetir a requisição e confirmar que não duplica o usuário no banco

[MY-110]: https://ederpontes2014.atlassian.net/browse/MY-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ