### PR TITLE
feat(auth): implementa endpoint /me com sincronização Keycloak via Ke…

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AuthController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AuthController.java
@@ -1,8 +1,10 @@
 package com.Mybuddy.Myb.Controller;
 
+import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Payload.Request.SignupRequest;
 import com.Mybuddy.Myb.Payload.Response.MessageResponse;
 import com.Mybuddy.Myb.Service.AuthService;
+import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,18 +16,19 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+    private final KeycloakUserSyncService keycloakUserSyncService;
 
-    public AuthController(AuthService authService) {
+    public AuthController(AuthService authService, KeycloakUserSyncService keycloakUserSyncService) {
         this.authService = authService;
+        this.keycloakUserSyncService = keycloakUserSyncService;
     }
 
-    // TODO MY-105: endpoint /me para retornar dados do usuário autenticado via Keycloak
     @GetMapping("/me")
-    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal Jwt jwt) {
-        return ResponseEntity.ok(new MessageResponse("Usuário: " + jwt.getClaimAsString("preferred_username")));
+    public ResponseEntity<Usuario> getCurrentUser(@AuthenticationPrincipal Jwt jwt) {
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(usuario);
     }
 
-    // TODO MY-110: avaliar se cadastro será via Keycloak Admin API
     @PostMapping("/cadastro")
     public ResponseEntity<?> registerUser(@Valid @RequestBody SignupRequest signUpRequest) {
         try {


### PR DESCRIPTION
## Task Jira
- **Card:** [MY-105](https://ederpontes2014.atlassian.net/browse/MY-105)
- **Tipo:** Feature

---
## O que foi feito?
Implementa endpoint `/api/auth/me` que retorna os dados do usuário autenticado sincronizados com o banco de dados via `KeycloakUserSyncService`.

Mudanças realizadas:
- `AuthController` — injetado `KeycloakUserSyncService`, endpoint `/me` atualizado para retornar entidade `Usuario` sincronizada com o banco
- Removido TODO provisório que retornava apenas o `preferred_username` do token

---
## Escopo das mudanças
- [x] `backend` — Java / Spring Boot

---
## Checklist de Testes
- [x] Testei localmente e o comportamento está conforme esperado
- [x] GET `/api/auth/me` com token Keycloak → retorna usuário sincronizado com `keycloakId` preenchido
- [x] Não há erros ou warnings novos no console
- [ ] Testes automatizados foram criados ou atualizados (MY-112 pendente)

---
## Checklist de Code Review
- [x] O código segue os padrões e convenções do projeto
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Dados sensíveis não estão expostos

---
## Notas para o Revisor
- O endpoint `/me` utiliza o mesmo `KeycloakUserSyncService` da MY-110 — cria o usuário no banco automaticamente se não existir
- O endpoint `/cadastro` foi mantido para registro manual via formulário

---
## Como testar
1. Subir containers: `docker compose up -d`
2. Obter token: `curl -X POST http://localhost:8080/realms/mybuddy/protocol/openid-connect/token -d "grant_type=password&client_id=mybuddy-frontend&username=davi&password=SUA_SENHA"`
3. GET `http://localhost:8081/api/auth/me` com `Authorization: Bearer TOKEN`
4. Verificar retorno com dados do usuário sincronizados com o banco

[MY-105]: https://ederpontes2014.atlassian.net/browse/MY-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ