### PR TITLE
test(auth): adiciona testes unitários da camada de segurança [MY-112]

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Exception/Handler/GlobalExceptionHandler.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Exception/Handler/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -49,6 +50,15 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(
                 new ErrorDetails(LocalDateTime.now(), ex.getMessage(), request.getDescription(false)),
                 HttpStatus.CONFLICT
+        );
+    }
+
+    @ExceptionHandler(AuthorizationDeniedException.class)
+    public ResponseEntity<ErrorDetails> handleAuthorizationDeniedException(AuthorizationDeniedException ex, WebRequest request) {
+        logger.warn("Acesso negado: {}", ex.getMessage());
+        return new ResponseEntity<>(
+                new ErrorDetails(LocalDateTime.now(), "Acesso negado", request.getDescription(false)),
+                HttpStatus.FORBIDDEN
         );
     }
 

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Controller/PetControllerTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Controller/PetControllerTest.java
@@ -1,0 +1,125 @@
+package com.Mybuddy.Myb.Controller;
+
+import com.Mybuddy.Myb.Config.SecurityConfig;
+import com.Mybuddy.Myb.DTO.PetRequestDTO;
+import com.Mybuddy.Myb.DTO.PetResponse;
+import com.Mybuddy.Myb.Security.JwtAuthConverter;
+import com.Mybuddy.Myb.Service.FotoPetService;
+import com.Mybuddy.Myb.Service.PetService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PetController.class)
+@Import({SecurityConfig.class, JwtAuthConverter.class})
+class PetControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PetService petService;
+
+    @MockBean
+    private FotoPetService fotoPetService;
+
+    @Test
+    void deveRetornar401QuandoSemToken() throws Exception {
+        mockMvc.perform(get("/api/pets"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deveRetornar200QuandoAutenticado() throws Exception {
+        when(petService.buscarComFiltrosDTO(any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/pets")
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void deveRetornar403QuandoUserTentaCriarPet() throws Exception {
+        mockMvc.perform(post("/api/pets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "nome": "Rex",
+                                    "especie": "CAO",
+                                    "raca": "Labrador",
+                                    "idade": 2,
+                                    "porte": "GRANDE",
+                                    "cor": "Amarelo",
+                                    "sexo": "M",
+                                    "castrado": true,
+                                    "vacinado": true,
+                                    "microchipado": false,
+                                    "statusAdocao": "DISPONIVEL",
+                                    "organizacaoId": 1
+                                }
+                                """)
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deveRetornar201QuandoOngCriaPet() throws Exception {
+        PetResponse petResponse = new PetResponse(
+                1L, "Rex", "CAO", "Labrador", 2, "GRANDE", "Amarelo",
+                null, "M", List.of(), "Em Adoção", null, "ONG Teste",
+                1L, false, true, true, null, null
+        );
+
+        when(petService.criarPet(any(PetRequestDTO.class))).thenReturn(petResponse);
+
+        mockMvc.perform(post("/api/pets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "nome": "Rex",
+                                    "especie": "CAO",
+                                    "raca": "Labrador",
+                                    "idade": 2,
+                                    "porte": "GRANDE",
+                                    "cor": "Amarelo",
+                                    "sexo": "M",
+                                    "castrado": true,
+                                    "vacinado": true,
+                                    "microchipado": false,
+                                    "statusAdocao": "DISPONIVEL",
+                                    "organizacaoId": 1
+                                }
+                                """)
+                        .with(jwt().authorities(() -> "ROLE_ONG")))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void deveRetornar204QuandoAdminDeletaPet() throws Exception {
+        mockMvc.perform(delete("/api/pets/1")
+                        .with(jwt().authorities(() -> "ROLE_ADMIN")))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    void deveRetornar403QuandoUserTentaDeletarPet() throws Exception {
+        mockMvc.perform(delete("/api/pets/1")
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isForbidden());
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Security/JwtAuthConverterTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Security/JwtAuthConverterTest.java
@@ -1,0 +1,91 @@
+package com.Mybuddy.Myb.Security;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtAuthConverterTest {
+
+    private JwtAuthConverter jwtAuthConverter;
+
+    @BeforeEach
+    void setUp() {
+        jwtAuthConverter = new JwtAuthConverter();
+    }
+
+    private Jwt buildJwt(Map<String, Object> claims) {
+        return Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .claims(c -> c.putAll(claims))
+                .build();
+    }
+
+    @Test
+    void deveExtrairRoleOngDoRealmAccess() {
+        Jwt jwt = buildJwt(Map.of(
+                "sub", "user-123",
+                "preferred_username", "davi",
+                "realm_access", Map.of("roles", List.of("ONG"))
+        ));
+
+        AbstractAuthenticationToken token = jwtAuthConverter.convert(jwt);
+        Collection<GrantedAuthority> authorities = token.getAuthorities();
+
+        assertThat(authorities)
+                .extracting(GrantedAuthority::getAuthority)
+                .contains("ROLE_ONG");
+    }
+
+    @Test
+    void deveExtrairRoleAdminDoRealmAccess() {
+        Jwt jwt = buildJwt(Map.of(
+                "sub", "user-123",
+                "preferred_username", "davi",
+                "realm_access", Map.of("roles", List.of("ADMIN"))
+        ));
+
+        AbstractAuthenticationToken token = jwtAuthConverter.convert(jwt);
+
+        assertThat(token.getAuthorities())
+                .extracting(GrantedAuthority::getAuthority)
+                .contains("ROLE_ADMIN");
+    }
+
+    @Test
+    void deveRetornarListaVaziaQuandoSemRealmAccess() {
+        Jwt jwt = buildJwt(Map.of(
+                "sub", "user-123",
+                "preferred_username", "davi"
+        ));
+
+        AbstractAuthenticationToken token = jwtAuthConverter.convert(jwt);
+
+        assertThat(token.getAuthorities())
+                .extracting(GrantedAuthority::getAuthority)
+                .doesNotContain("ROLE_ONG", "ROLE_ADMIN");
+    }
+
+    @Test
+    void devePegarPreferredUsernameComoPrincipal() {
+        Jwt jwt = buildJwt(Map.of(
+                "sub", "user-123",
+                "preferred_username", "davi",
+                "realm_access", Map.of("roles", List.of("USER"))
+        ));
+
+        AbstractAuthenticationToken token = jwtAuthConverter.convert(jwt);
+
+        assertThat(token.getName()).isEqualTo("davi");
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/KeycloakUserSyncServiceTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/KeycloakUserSyncServiceTest.java
@@ -1,0 +1,110 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class KeycloakUserSyncServiceTest {
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @InjectMocks
+    private KeycloakUserSyncService keycloakUserSyncService;
+
+    private Jwt jwt;
+
+    @BeforeEach
+    void setUp() {
+        jwt = Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .claims(c -> c.putAll(Map.of(
+                        "sub", "keycloak-id-123",
+                        "email", "pedro@mybuddy.com",
+                        "name", "Pedro Lira",
+                        "preferred_username", "pedro"
+                )))
+                .build();
+    }
+
+    @Test
+    void deveRetornarUsuarioExistenteQuandoKeycloakIdJaCadastrado() {
+        Usuario usuarioExistente = new Usuario();
+        usuarioExistente.setKeycloakId("keycloak-id-123");
+        usuarioExistente.setEmail("pedro@mybuddy.com");
+
+        when(usuarioRepository.findByKeycloakId("keycloak-id-123"))
+                .thenReturn(Optional.of(usuarioExistente));
+
+        Usuario resultado = keycloakUserSyncService.syncUsuario(jwt);
+
+        assertThat(resultado.getKeycloakId()).isEqualTo("keycloak-id-123");
+        verify(usuarioRepository, never()).save(any());
+    }
+
+    @Test
+    void deveCriarUsuarioQuandoKeycloakIdNaoExiste() {
+        Usuario usuarioNovo = new Usuario();
+        usuarioNovo.setKeycloakId("keycloak-id-123");
+        usuarioNovo.setEmail("pedro@mybuddy.com");
+        usuarioNovo.setNome("Pedro Lira");
+        usuarioNovo.setPassword("KEYCLOAK_MANAGED");
+
+        when(usuarioRepository.findByKeycloakId("keycloak-id-123"))
+                .thenReturn(Optional.empty());
+        when(usuarioRepository.save(any(Usuario.class)))
+                .thenReturn(usuarioNovo);
+
+        Usuario resultado = keycloakUserSyncService.syncUsuario(jwt);
+
+        assertThat(resultado.getKeycloakId()).isEqualTo("keycloak-id-123");
+        assertThat(resultado.getEmail()).isEqualTo("pedro@mybuddy.com");
+        assertThat(resultado.getNome()).isEqualTo("Pedro Lira");
+        assertThat(resultado.getPassword()).isEqualTo("KEYCLOAK_MANAGED");
+        verify(usuarioRepository).save(any(Usuario.class));
+    }
+
+    @Test
+    void deveUsarPreferredUsernameQuandoNameForNulo() {
+        Jwt jwtSemName = Jwt.withTokenValue("token")
+                .header("alg", "RS256")
+                .issuedAt(Instant.now())
+                .expiresAt(Instant.now().plusSeconds(300))
+                .claims(c -> c.putAll(Map.of(
+                        "sub", "keycloak-id-123",
+                        "email", "pedro@mybuddy.com",
+                        "preferred_username", "Pedro"
+                )))
+                .build();
+
+        Usuario usuarioNovo = new Usuario();
+        usuarioNovo.setNome("Pedro");
+
+        when(usuarioRepository.findByKeycloakId("keycloak-id-123"))
+                .thenReturn(Optional.empty());
+        when(usuarioRepository.save(any(Usuario.class)))
+                .thenReturn(usuarioNovo);
+
+        Usuario resultado = keycloakUserSyncService.syncUsuario(jwtSemName);
+
+        assertThat(resultado.getNome()).isEqualTo("Pedro");
+    }
+}


### PR DESCRIPTION
## Task Jira
- **Card:** [MY-112](https://ederpontes2014.atlassian.net/browse/MY-112)
- **Tipo:** test

---
## O que foi feito?
Implementa testes unitários da camada de segurança cobrindo os principais componentes de autenticação e autorização via Keycloak.

Testes criados:
- `JwtAuthConverterTest` — 4 testes: extração de roles do `realm_access`, fallback sem roles, validação do `preferred_username` como principal
- `KeycloakUserSyncServiceTest` — 3 testes: retorno de usuário existente por `keycloakId`, criação automática de novo usuário, uso do `preferred_username` quando `name` é nulo
- `PetControllerTest` — 6 testes: 401 sem token, 200 autenticado, 403 USER tentando criar pet, 201 ONG criando pet, 204 ADMIN deletando pet, 403 USER tentando deletar pet

Correção adicional:
- `GlobalExceptionHandler` — adicionado handler para `AuthorizationDeniedException` retornando 403 em vez de 500

**Total: 13/13 testes passando**

---
## Escopo das mudanças
- [x] `backend` — Java / Spring Boot

---
## Checklist de Testes
- [x] 13 testes unitários passando
- [x] Nenhuma regressão nos testes existentes
- [x] BUILD SUCCESS

---
## Checklist de Code Review
- [x] O código segue os padrões e convenções do projeto
- [x] Testes com nomes descritivos em português seguindo o padrão do projeto
- [x] Mocks utilizados corretamente com Mockito
- [x] `@WebMvcTest` com `@Import` do `SecurityConfig` para testes de controller

---
## Notas para o Revisor
- `GlobalExceptionHandler` estava retornando 500 para `AuthorizationDeniedException` — corrigido para 403
- `PetControllerTest` usa `@Import({SecurityConfig.class, JwtAuthConverter.class})` para carregar a configuração de segurança corretamente no contexto de teste
- MY-114 (testes de integração com Testcontainers + Keycloak) pendente

---
## Como testar
1. Rodar todos os testes: `./mvnw test`
2. Verificar que 13 testes passam sem falhas

[MY-112]: https://ederpontes2014.atlassian.net/browse/MY-112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ