### PR TITLE
My 121 criar keycloak init service com init options

### DIFF
--- a/Front End - Angular/mybuddy/public/silent-check-sso.html
+++ b/Front End - Angular/mybuddy/public/silent-check-sso.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <script>
+        parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/Front End - Angular/mybuddy/src/app/app.config.browser.ts
+++ b/Front End - Angular/mybuddy/src/app/app.config.browser.ts
@@ -1,0 +1,22 @@
+import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
+import { environment } from '../environments/environment';
+import { appConfig } from './app.config';
+import { provideKeycloak } from 'keycloak-angular';
+
+const browserConfig: ApplicationConfig = {
+    providers: [
+        provideKeycloak({
+            config:{
+                url: environment.keycloak.url,
+                realm: environment.keycloak.realm,
+                clientId: environment.keycloak.clientId,
+            },
+            initOptions: {
+                onLoad: 'check-sso',
+                silentCheckSsoRedirectUri: environment.keycloak.silentCheckSsoRedirectUri,
+            },
+        }),
+    ],
+};
+
+export const config = mergeApplicationConfig(appConfig, browserConfig);

--- a/Front End - Angular/mybuddy/src/app/app.config.browser.ts
+++ b/Front End - Angular/mybuddy/src/app/app.config.browser.ts
@@ -1,6 +1,6 @@
 import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
 import { environment } from '../environments/environment';
-import { appConfig } from './app.config';
+import { appConfig } from './app.config';   
 import { provideKeycloak } from 'keycloak-angular';
 
 const browserConfig: ApplicationConfig = {

--- a/Front End - Angular/mybuddy/src/app/app.config.ts
+++ b/Front End - Angular/mybuddy/src/app/app.config.ts
@@ -1,8 +1,11 @@
 import {
   ApplicationConfig,
+  inject,
+  PLATFORM_ID,
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
 } from '@angular/core';
+
 import { provideRouter, withViewTransitions, withComponentInputBinding } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -15,6 +18,7 @@ import { provideHttpClient, withFetch } from '@angular/common/http';
 
 import { provideKeycloak } from 'keycloak-angular';
 import { environment } from '../environments/environment';
+import { isPlatformBrowser } from '@angular/common';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -27,7 +31,9 @@ export const appConfig: ApplicationConfig = {
 
       initOptions: {
         onLoad: 'check-sso',
-        silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',
+        silentCheckSsoRedirectUri: isPlatformBrowser(inject(PLATFORM_ID))
+          ? `${window.location.origin}/silent-check-sso.html`
+          : '',
       },
     }),
     provideBrowserGlobalErrorListeners(),

--- a/Front End - Angular/mybuddy/src/app/app.config.ts
+++ b/Front End - Angular/mybuddy/src/app/app.config.ts
@@ -1,11 +1,8 @@
 import {
   ApplicationConfig,
-  inject,
-  PLATFORM_ID,
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
 } from '@angular/core';
-
 import { provideRouter, withViewTransitions, withComponentInputBinding } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -16,26 +13,8 @@ import { MyBuddyPreset } from '../styles/mypreset';
 
 import { provideHttpClient, withFetch } from '@angular/common/http';
 
-import { provideKeycloak } from 'keycloak-angular';
-import { environment } from '../environments/environment';
-import { isPlatformBrowser } from '@angular/common';
-
 export const appConfig: ApplicationConfig = {
   providers: [
-    provideKeycloak({
-      config: {
-        url: environment.keycloak.url,
-        realm: environment.keycloak.realm,
-        clientId: environment.keycloak.clientId,
-      },
-
-      initOptions: {
-        onLoad: 'check-sso',
-        silentCheckSsoRedirectUri: isPlatformBrowser(inject(PLATFORM_ID))
-          ? `${window.location.origin}/silent-check-sso.html`
-          : '',
-      },
-    }),
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes, withComponentInputBinding(), withViewTransitions()),
     provideClientHydration(withEventReplay()),

--- a/Front End - Angular/mybuddy/src/app/app.config.ts
+++ b/Front End - Angular/mybuddy/src/app/app.config.ts
@@ -13,8 +13,23 @@ import { MyBuddyPreset } from '../styles/mypreset';
 
 import { provideHttpClient, withFetch } from '@angular/common/http';
 
+import { provideKeycloak } from 'keycloak-angular';
+import { environment } from '../environments/environment';
+
 export const appConfig: ApplicationConfig = {
   providers: [
+    provideKeycloak({
+      config: {
+        url: environment.keycloak.url,
+        realm: environment.keycloak.realm,
+        clientId: environment.keycloak.clientId,
+      },
+
+      initOptions: {
+        onLoad: 'check-sso',
+        silentCheckSsoRedirectUri: window.location.origin + '/silent-check-sso.html',
+      },
+    }),
     provideBrowserGlobalErrorListeners(),
     provideRouter(routes, withComponentInputBinding(), withViewTransitions()),
     provideClientHydration(withEventReplay()),

--- a/Front End - Angular/mybuddy/src/environments/environment.development.ts
+++ b/Front End - Angular/mybuddy/src/environments/environment.development.ts
@@ -2,7 +2,7 @@ export const environment = {
     production: false,
     apiUrl: 'https://localhost:8081/api/',
     envName: 'Development',
-    Keycloak: {
+    keycloak: {
         url: 'https://localhost:8080',
         realm: 'mybuddy',
         clientId: 'mybuddy-frontend',

--- a/Front End - Angular/mybuddy/src/environments/environment.development.ts
+++ b/Front End - Angular/mybuddy/src/environments/environment.development.ts
@@ -6,5 +6,6 @@ export const environment = {
         url: 'https://localhost:8080',
         realm: 'mybuddy',
         clientId: 'mybuddy-frontend',
+        silentCheckSsoRedirectUri: 'http://localhost:4200/silent-check-sso.html',
     },
 };

--- a/Front End - Angular/mybuddy/src/environments/environment.development.ts
+++ b/Front End - Angular/mybuddy/src/environments/environment.development.ts
@@ -1,6 +1,10 @@
 export const environment = {
-  production: false,
-  apiUrl: 'http://localhost:8081/api',
-  envName: 'development',
-  keycloakUrl: 'http://localhost:8080'
+    production: false,
+    apiUrl: 'https://localhost:8081/api/',
+    envName: 'Development',
+    Keycloak: {
+        url: 'https://localhost:8080',
+        realm: 'mybuddy',
+        clientId: 'mybuddy-frontend',
+    },
 };

--- a/Front End - Angular/mybuddy/src/environments/environment.ts
+++ b/Front End - Angular/mybuddy/src/environments/environment.ts
@@ -6,5 +6,6 @@ export const environment = {
         url: 'http://localhost:8080',
         realm: 'mybuddy',
         clientId: 'mybuddy-frontend',
+        //silentCheckSsoRedirectUri: 'https://nossaurl.com/silent-check-sso.html',  
     },
 };

--- a/Front End - Angular/mybuddy/src/environments/environment.ts
+++ b/Front End - Angular/mybuddy/src/environments/environment.ts
@@ -6,6 +6,6 @@ export const environment = {
         url: 'http://localhost:8080',
         realm: 'mybuddy',
         clientId: 'mybuddy-frontend',
-        //silentCheckSsoRedirectUri: 'https://nossaurl.com/silent-check-sso.html',  
+        silentCheckSsoRedirectUri: 'https://nossaurl.com/silent-check-sso.html',  
     },
 };

--- a/Front End - Angular/mybuddy/src/environments/environment.ts
+++ b/Front End - Angular/mybuddy/src/environments/environment.ts
@@ -1,6 +1,10 @@
 export const environment = {
-  production: true,
-  apiUrl: '/api',
-  envName: 'production',
-  keycloakUrl: 'http://localhost:8080'
+    production: true,
+    apiUrl: '/api',
+    envName: 'production',
+    keycloak: {
+        url: 'http://localhost:8080',
+        realm: 'mybuddy',
+        clientId: 'mybuddy-frontend',
+    },
 };

--- a/Front End - Angular/mybuddy/src/main.ts
+++ b/Front End - Angular/mybuddy/src/main.ts
@@ -1,5 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig } from './app/app.config';
+import { config } from './app/app.config.browser';
 import { App } from './app/app';
 
-bootstrapApplication(App, appConfig).catch(err => console.error(err));
+bootstrapApplication(App, config).catch((err) => console.error(err));


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-121](https://ederpontes2014.atlassian.net/browse/MY-121)
- **Tipo:** Feature

---

## O que foi feito?

Configura a inicialização do Keycloak no contexto browser via provideKeycloak, isolando o provider em app.config.browser.ts para evitar erros de SSR. Adiciona variáveis de ambiente do Keycloak (url, realm, clientId, silentCheckSsoRedirectUri) nos arquivos de environment e cria o silent-check-sso.html na pasta public.

---

## Escopo das mudanças

- [x] `frontend` — Angular

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [x] Validei em mais de um ambiente

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)

---

## Notas para o Revisor

O provideKeycloak foi isolado em app.config.browser.ts e referenciado no main.ts, enquanto o app.config.server.ts continua usando apenas app.config.ts. Isso evita que o keycloak-js tente acessar window durante o SSR. O onLoad foi configurado como check-sso com silent-check-sso.html servido estaticamente pela pasta public.

---

## Como testar

1. Rodar a aplicação com npm start
2. Abrir http://localhost:4200 e verificar que o console não apresenta erros
3. Abrir DevTools > Network e filtrar por keycloak
4. Confirmar requisição para http://localhost:8080/realms/mybuddy/.well-known/openid-configuration com status 200 ou 304

[MY-121]: https://ederpontes2014.atlassian.net/browse/MY-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ