### PR TITLE
fix(frontend): remove provideHttpClient duplicado do app.config.ts

### DIFF
--- a/Front End - Angular/mybuddy/src/app/app.config.browser.ts
+++ b/Front End - Angular/mybuddy/src/app/app.config.browser.ts
@@ -1,12 +1,24 @@
 import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
 import { environment } from '../environments/environment';
 import { appConfig } from './app.config';
-import { provideKeycloak } from 'keycloak-angular';
+import { authInterceptor } from './core/interceptors/auth.interceptor';
+import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
+import { provideKeycloak, INCLUDE_BEARER_TOKEN_INTERCEPTOR_CONFIG } from 'keycloak-angular';
 
 const browserConfig: ApplicationConfig = {
     providers: [
+        provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
+        {
+            provide: INCLUDE_BEARER_TOKEN_INTERCEPTOR_CONFIG,
+            useValue: [
+                {
+                    urlPattern: /^(http:\/\/localhost:8081)(\/.*)?$/,
+                    bearerPrefix: "Bearer "
+                },
+            ]
+        },
         provideKeycloak({
-            config:{
+            config: {
                 url: environment.keycloak.url,
                 realm: environment.keycloak.realm,
                 clientId: environment.keycloak.clientId,

--- a/Front End - Angular/mybuddy/src/app/app.config.ts
+++ b/Front End - Angular/mybuddy/src/app/app.config.ts
@@ -7,11 +7,8 @@ import { provideRouter, withViewTransitions, withComponentInputBinding } from '@
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
-
 import { providePrimeNG } from 'primeng/config';
 import { MyBuddyPreset } from '../styles/mypreset';
-
-import { provideHttpClient, withFetch } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -19,7 +16,6 @@ export const appConfig: ApplicationConfig = {
     provideRouter(routes, withComponentInputBinding(), withViewTransitions()),
     provideClientHydration(withEventReplay()),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideHttpClient(withFetch()),
     providePrimeNG({
       theme: {
         preset: MyBuddyPreset,

--- a/Front End - Angular/mybuddy/src/app/core/interceptors/auth.interceptor.ts
+++ b/Front End - Angular/mybuddy/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,8 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
+import {
+    includeBearerTokenInterceptor,
+    INCLUDE_BEARER_TOKEN_INTERCEPTOR_CONFIG
+} from 'keycloak-angular';
+
+export const authInterceptor: HttpInterceptorFn = includeBearerTokenInterceptor;


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-128](https://ederpontes2014.atlassian.net/browse/MY-128)
- **Tipo:** Feature

---

## O que foi feito?

Adiciona interceptor HTTP para injetar o Bearer token do Keycloak nas requisições ao backend. O interceptor usa o includeBearerTokenInterceptor do keycloak-angular@21, configurado para atuar apenas nas requisições destinadas ao localhost:8081. O provideHttpClient foi movido do app.config.ts para o app.config.browser.ts para centralizar a configuração do contexto browser.

---

## Escopo das mudanças

- [x] `frontend` — Angular

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Não há erros ou warnings novos no console

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)

---

## Notas para o Revisor

O interceptor só injeta o token em requisições que casam com o padrão `http://localhost:8081/*`. Requisições externas como o discovery do Keycloak não recebem o token. O provideHttpClient foi consolidado no app.config.browser.ts junto com o provideKeycloak, mantendo o app.config.ts agnóstico ao contexto de execução.

---

## Como testar

1. Rodar a aplicação com ng serve
2. Fazer login no Keycloak
3. Abrir DevTools > Network e realizar uma requisição ao backend
4. Verificar que o header Authorization: Bearer <token> está presente na requisição

[MY-128]: https://ederpontes2014.atlassian.net/browse/MY-128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ