### PR TITLE
feat(frontend): adiciona AuthGuard e protege rotas home e pets

### DIFF
--- a/Front End - Angular/mybuddy/src/app/app.routes.ts
+++ b/Front End - Angular/mybuddy/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './core/guards/auth.guards';
 
 export const routes: Routes = [
   {
@@ -9,11 +10,13 @@ export const routes: Routes = [
   {
     // Rota para a página inicial (home)
     path: 'home',
+    canActivate: [authGuard],
     loadComponent: () => import('./features/home/home').then(m => m.Home),
   },
   {
     // Rota para a página de pets
     path: 'pets',
+    canActivate: [authGuard],
     loadComponent: () => import('./features/pets/pets').then(m => m.Pets),
   },
   {

--- a/Front End - Angular/mybuddy/src/app/core/guards/auth.guards.ts
+++ b/Front End - Angular/mybuddy/src/app/core/guards/auth.guards.ts
@@ -1,0 +1,18 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import Keycloak from 'keycloak-js';
+
+export const authGuard: CanActivateFn = () => {
+    const keycloak = inject(Keycloak);
+    const router = inject(Router);
+
+    if (keycloak.authenticated){
+        return true;
+    }
+
+    keycloak.login({
+        redirectUri: window.location.origin + '/home',
+    });
+
+    return false;
+}


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-124](https://ederpontes2014.atlassian.net/browse/MY-124)
- **Tipo:** Feature

---

## O que foi feito?

Adiciona AuthGuard funcional usando CanActivateFn que verifica se o usuário está autenticado via Keycloak. Caso não esteja, redireciona automaticamente para o fluxo de login do Keycloak com redirectUri apontando para /home. Guard aplicado nas rotas home e pets.

---

## Escopo das mudanças

- [x] `frontend` — Angular

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Não há erros ou warnings novos no console

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)

---

## Notas para o Revisor

A classe Keycloak é importada do keycloak-js e não do keycloak-angular, pois o keycloak-angular@21 não reexporta a classe principal. O Router foi injetado mas não utilizado diretamente pois o redirect é feito via keycloak.login() — pode ser removido numa revisão futura.

---

## Como testar

1. Rodar a aplicação com ng serve
2. Acessar http://localhost:4200/home sem estar autenticado
3. Verificar que o browser redireciona para a tela de login do Keycloak
4. Após login, confirmar que retorna para /home

[MY-124]: https://ederpontes2014.atlassian.net/browse/MY-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ