### PR TITLE
fix(frontend): corrige url do keycloak de https para http nos environ…

### DIFF
--- a/Front End - Angular/mybuddy/src/app/app.routes.server.ts
+++ b/Front End - Angular/mybuddy/src/app/app.routes.server.ts
@@ -2,6 +2,18 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 
 export const serverRoutes: ServerRoute[] = [
   {
+    path: '',
+    renderMode: RenderMode.Prerender,
+  },
+  {
+    path: 'home',
+    renderMode: RenderMode.Client,
+  },
+  {
+    path: 'pets',
+    renderMode: RenderMode.Client,
+  },
+  {
     path: '**',
     renderMode: RenderMode.Prerender,
   },

--- a/Front End - Angular/mybuddy/src/environments/environment.development.ts
+++ b/Front End - Angular/mybuddy/src/environments/environment.development.ts
@@ -3,7 +3,7 @@ export const environment = {
     apiUrl: 'https://localhost:8081/api/',
     envName: 'Development',
     keycloak: {
-        url: 'https://localhost:8080',
+        url: 'http://localhost:8080',
         realm: 'mybuddy',
         clientId: 'mybuddy-frontend',
         silentCheckSsoRedirectUri: 'http://localhost:4200/silent-check-sso.html',

--- a/Front End - Angular/mybuddy/src/environments/environment.ts
+++ b/Front End - Angular/mybuddy/src/environments/environment.ts
@@ -6,6 +6,6 @@ export const environment = {
         url: 'http://localhost:8080',
         realm: 'mybuddy',
         clientId: 'mybuddy-frontend',
-        silentCheckSsoRedirectUri: 'https://nossaurl.com/silent-check-sso.html',  
+        silentCheckSsoRedirectUri: 'http://localhost:4200/silent-check-sso.html',  
     },
 };


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-124](https://ederpontes2014.atlassian.net/browse/MY-124)
- **Tipo:** Fix

---

## O que foi feito?

Corrige a URL do Keycloak no environment de desenvolvimento de https para http e reverte o onLoad de login-required para check-sso.

---

## Escopo das mudanças

- [x] `frontend` — Angular

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Não há erros ou warnings novos no console

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)

---

## Notas para o Revisor

A URL estava configurada com https no environment de desenvolvimento causando ERR_SSL_PROTOCOL_ERROR ao tentar redirecionar para o Keycloak local. Corrigido para http://localhost:8080. onLoad revertido para check-sso após confirmação que o erro era exclusivamente na URL.

---

## Como testar

1. Rodar a aplicação com ng serve
2. Acessar http://localhost:4200/home sem estar autenticado
3. Confirmar que o browser redireciona para http://localhost:8080 sem erro de SSL

[MY-124]: https://ederpontes2014.atlassian.net/browse/MY-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ