### PR TITLE
chore(infra): adiciona rede interna mybuddy-network entre os servicos…

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/docker-compose.yml
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_PASSWORD: keycloak
     ports:
       - 5432:5432
+    networks:
+      - mybuddy-network
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.5.5
@@ -25,4 +27,11 @@ services:
       - 8080:8080
     depends_on:
       - postgres
+    networks:
+      - mybuddy-network
+
+networks:
+  mybuddy-network:
+    name: mybuddy_network
+    driver: bridge
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,9 @@ services:
     volumes:
       - mongodb-data:/data/db
 
+    networks:
+      - mybuddy-network
+
   # ── PostgreSQL (banco do Keycloak e do backend) ───────────
   postgres:
     image: postgres:16-alpine
@@ -35,6 +38,9 @@ services:
     # MY-243 → dados do PostgreSQL persistem entre reinicializações
     volumes:
       - postgres-data:/var/lib/postgresql/data
+
+    networks:
+      - mybuddy-network
 
   # ── MY-242: Keycloak ──────────────────────────────────────
   keycloak:
@@ -63,6 +69,9 @@ services:
     depends_on:
       - postgres
 
+    networks:
+      - mybuddy-network
+
 # ── MY-243: Declaração dos volumes ───────────────────────────
 # Dados salvos mesmo após "docker compose down"
 # Para apagar tudo: docker compose down -v
@@ -72,3 +81,11 @@ volumes:
 
   postgres-data:
     name: mybuddy_postgres_data
+
+  networks:
+    mybuddy-network:
+
+networks:
+  mybuddy-network:
+   name: mybuddy_network
+   driver: bridge


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-247](https://ederpontes2014.atlassian.net/browse/MY-247)
- **Tipo:** Chore

---

## O que foi feito?

Completa o .env raiz com todas as variáveis necessárias: datasource do PostgreSQL, URI do MongoDB, secrets do Keycloak e JWT, e porta do frontend.

---

## Escopo das mudanças

- [x] `infra` — Docker / CI / configurações

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado

---

## Notas para o Revisor

O .env raiz centraliza todas as variáveis do ambiente Docker. O .env do backend em Back End/JavaSpring/Myb Def/backend-mybuddy/.env é usado apenas para dev local fora do Docker.

[MY-247]: https://ederpontes2014.atlassian.net/browse/MY-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ