### PR TITLE
Finalizando modal

### DIFF
--- a/Front End - Angular/mybuddy/src/app/shared/components/modal/modal.component.html
+++ b/Front End - Angular/mybuddy/src/app/shared/components/modal/modal.component.html
@@ -1,0 +1,26 @@
+<p-dialog
+  [(visible)]="visible"
+  [header]="title"
+  [modal]="true"
+  [draggable]="false"
+  [resizable]="false"
+  [style]="{ width: width }"
+  (onHide)="onHide()"
+>
+  <ng-content />
+
+  <ng-template #footer *ngIf="showFooter">
+    <p-button
+      [label]="cancelLabel"
+      severity="secondary"
+      [outlined]="true"
+      (onClick)="onCancel()"
+    />
+    <p-button
+      [label]="confirmLabel"
+      [severity]="confirmSeverity"
+      [loading]="loading"
+      (onClick)="onConfirm()"
+    />
+  </ng-template>
+</p-dialog>

--- a/Front End - Angular/mybuddy/src/app/shared/components/modal/modal.component.scss
+++ b/Front End - Angular/mybuddy/src/app/shared/components/modal/modal.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: contents;
+}

--- a/Front End - Angular/mybuddy/src/app/shared/components/modal/modal.component.ts
+++ b/Front End - Angular/mybuddy/src/app/shared/components/modal/modal.component.ts
@@ -1,0 +1,42 @@
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DialogModule } from 'primeng/dialog';
+import { ButtonModule } from 'primeng/button';
+
+@Component({
+  selector: 'app-modal',
+  standalone: true,
+  imports: [CommonModule, DialogModule, ButtonModule],
+  templateUrl: './modal.component.html',
+  styleUrl: './modal.component.scss',
+})
+export class ModalComponent {
+  @Input() visible = false;
+  @Input() title = '';
+  @Input() width = '450px';
+  @Input() showFooter = true;
+  @Input() confirmLabel = 'Confirmar';
+  @Input() cancelLabel = 'Cancelar';
+  @Input() confirmSeverity: 'primary' | 'secondary' | 'danger' = 'primary';
+  @Input() loading = false;
+
+  @Output() visibleChange = new EventEmitter<boolean>();
+  @Output() confirm = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  onHide(): void {
+    this.visible = false;
+    this.visibleChange.emit(false);
+    this.cancel.emit();
+  }
+
+  onConfirm(): void {
+    this.confirm.emit();
+  }
+
+  onCancel(): void {
+    this.visible = false;
+    this.visibleChange.emit(false);
+    this.cancel.emit();
+  }
+}


### PR DESCRIPTION
## Task Jira
> Vincule a task relacionada a este PR
- **Card:** [MYB-178](https://mybuddy.atlassian.net/browse/MYB-178)
- **Tipo:** Feature
---
## O que foi feito?
Implementa o componente `ModalComponent` genérico e reutilizável utilizando o `p-dialog` do PrimeNG, com suporte a título, conteúdo via `ng-content`, botões de confirmação e cancelamento configuráveis via `@Input`, e eventos de saída via `@Output`.

---
## Escopo das mudanças
- [ ] `backend` — Java / Spring Boot
- [x] `frontend` — Angular
- [ ] `mobile` — Flutter
- [ ] `infra` — Docker / CI / configurações
---
## Checklist de Testes
- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [ ] Testes automatizados foram criados ou atualizados (se aplicável)
---
## Checklist de Code Review
- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e são reversíveis
---
## Notas para o Revisor
- O componente foi criado em `src/app/shared/components/modal/` seguindo o padrão standalone já adotado no projeto
- Utiliza o `p-dialog` do PrimeNG que já está configurado globalmente com o `MyBuddyPreset`
- O conteúdo interno é projetado via `ng-content`, permitindo que qualquer conteúdo seja inserido sem modificar o componente
- O footer (botões) pode ser ocultado via `@Input() showFooter = false` para casos onde apenas conteúdo informativo é exibido
- O botão de confirmação aceita `severity: primary | secondary | danger` para cobrir casos como exclusão
---
## Como testar
```
1. Importar o ModalComponent no componente desejado
2. Adicionar <app-modal [(visible)]="modalAberto" title="Teste" (confirm)="onConfirm()">
     <p>Conteúdo de teste</p>
   </app-modal> no template
3. Disparar a abertura do modal via botão e validar que abre/fecha corretamente
4. Validar que os eventos (confirm) e (cancel) são emitidos corretamente
5. Testar com confirmSeverity="danger" para validar o estilo do botão de confirmação
```