### PR TITLE
feat(backend-MP)MY-179: Criar entidade Payment e PaymentStatus no banco

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Rodar testes com Maven
         run: mvn test
         working-directory: "Back End/JavaSpring/Myb Def/backend-mybuddy"
+        env:
+          MERCADOPAGO_ACCESS_TOKEN: ${{ secrets.MERCADOPAGO_ACCESS_TOKEN }}
+
 
       - name: Publicar relatório do Jacoco
         uses: actions/upload-artifact@v4

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/MercadoPagoConfig.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/MercadoPagoConfig.java
@@ -1,0 +1,18 @@
+package com.Mybuddy.Myb.Config;
+
+import org.springframework.context.annotation.Configuration;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+
+@Configuration
+public class MercadoPagoConfig {
+    
+    @Value("${mercadopago.access_token}")
+    private String accessToken;
+
+    @PostConstruct
+    public void init() {
+        System.setProperty("mercadopago.access_token", accessToken);
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Payment.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Payment.java
@@ -1,0 +1,61 @@
+package com.Mybuddy.Myb.Model;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "payments")
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+public class Payment {
+    
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
+    private Long id;
+
+    @Column(name = "mp_preference_id", unique = true)
+    private String mpPreferenceId;
+
+    @Column(name = "mp_payment_id")
+    private String mpPaymentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name= "Usuario_id", nullable = false)
+    private Usuario usuario;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", nullable = false)
+    private Pet pet;
+
+    @Column(nullable = false, precision = 10, scale = 2)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PaymentStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+        this.status = PaymentStatus.PENDING;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/PaymentStatus.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/PaymentStatus.java
@@ -1,0 +1,9 @@
+package com.Mybuddy.Myb.Model;
+
+public enum PaymentStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+    CANCELLED,
+    REFUNDED
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       retries: 5
       start_period: 20s
 
-  # ── PostgreSQL (banco do Keycloak e do backend) ───────────
+  # ── PostgreSQL (banco do backend) ───────────
   postgres:
     image: postgres:16-alpine
     container_name: mybuddy-postgres
@@ -118,6 +118,8 @@ services:
       JWT_SECRET: ${JWT_SECRET}
       JWT_EXPIRATION_MS: ${JWT_EXPIRATION_MS}
       UPLOAD_DIR: ${UPLOAD_DIR}
+      MERCADOPAGO_ACCESS_TOKEN: ${MERCADOPAGO_ACCESS_TOKEN}
+
 
     ports:
       - "8081:8081"


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-179](https://ederpontes2014.atlassian.net/browse/MY-179)
- **Tipo:** Feature

---

## O que foi feito?

Criação da entidade JPA `Payment` e do enum `PaymentStatus` para representar pagamentos na plataforma. A tabela `payments` foi gerada automaticamente pelo Hibernate no PostgreSQL com os campos de preferência e pagamento do Mercado Pago, referências ao usuário e pet, valor, status e timestamps de auditoria.

---

## Escopo das mudanças

- [x] `backend` — Java / Spring Boot

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Não há erros ou warnings novos no console
- [x] Tabela `payments` criada corretamente no banco PostgreSQL

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos

---

## Notas para o Revisor

- `PaymentStatus` usa valores em inglês (`PENDING`, `APPROVED`, `REJECTED`, `CANCELLED`, `REFUNDED`) para consistência com o SDK do Mercado Pago
- `@PrePersist` define status inicial como `PENDING` automaticamente
- Relacionamentos com `Usuario` e `Pet` são `@ManyToOne` sem `@OneToMany` reverso para evitar N+1

---

## Como testar

```
1. Subir o docker compose
2. Executar: docker exec mybuddy-postgres psql -U mybuddy -d mybuddy -c "\dt"
3. Confirmar que a tabela payments aparece na listagem
```

[MY-179]: https://ederpontes2014.atlassian.net/browse/MY-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ