### PR TITLE
feat: MY-207: Implementar validação de assinatura x-signature do webh…

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PaymentController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PaymentController.java
@@ -8,6 +8,7 @@ import com.Mybuddy.Myb.Model.Payment;
 import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
 import com.Mybuddy.Myb.Service.PaymentService;
+import com.Mybuddy.Myb.Util.MercadoPagoWebhookValidator;
 import com.mercadopago.exceptions.MPApiException;
 import com.mercadopago.exceptions.MPException;
 
@@ -33,6 +34,7 @@ public class PaymentController {
     private final PaymentService paymentService;
     private final KeycloakUserSyncService keycloakUserSyncService;
     private final ApplicationEventPublisher eventPublisher;
+    private final MercadoPagoWebhookValidator webhookValidator;
 
     @PostMapping("/create")
     @PreAuthorize("isAuthenticated()")
@@ -80,27 +82,39 @@ public class PaymentController {
     }
 
     @PostMapping("/webhook")
-    public ResponseEntity<Void> webhook(@RequestBody Map<String,
-         Object> payload, @RequestHeader Map<String, String> headers) {
-        
+    public ResponseEntity<Void> webhook (
+            @RequestBody Map<String, Object> payload,
+            @RequestHeader(value = "x-signature", required = false) String xSignature,
+            @RequestHeader(value = "x-request-id", required = false) String xRequestId){
+
         log.info("Webhook MP recebido: {}", payload);
+        
+        String dataId = null;
+        if (payload.get("data") instanceof Map<?, ?> data) {
+
+            dataId = String.valueOf(data.get("id"));
+        } else if (payload.get("id") != null) {
+            dataId = String.valueOf(payload.get("id"));
+        }
+
+        if (!webhookValidator.isValid(xSignature, xRequestId, dataId)) {
+            log.warn("Webhook rejeitado — assinatura inválida");
+            return ResponseEntity.status(401).build();
+        }
 
         String topic = (String) payload.get("topic");
         String type = (String) payload.get("type");
 
-        if ("payment".equals(topic) || "payment".equals(type)) {
-            Object dataId = payload.get("id");
-            if (dataId == null && payload.get("data") instanceof Map<?,?> data) {
-                dataId = data.get("id");
-            }
-            if (dataId != null) {
-                eventPublisher.publishEvent(
-                    new PaymentWebhookEvent(this, dataId.toString(), topic != null ? topic : type)
-                );
-            } else {
-                log.warn("Webhook MP recebido sem ID: {}", payload);
-            }
+        if ("payment".equals(topic) || "payment.updated".equals(type)) {
+            eventPublisher.publishEvent(
+                new PaymentWebhookEvent(this, dataId, topic != null ? topic : type
+
+            ));
+        } else {
+            log.info("Webhook MP ignorado — topic ou type não tratado. topic={}, type={}", topic, type);
         }
+
+
         return ResponseEntity.ok().build();
     }
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
@@ -1,0 +1,62 @@
+package com.Mybuddy.Myb.Util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+@Slf4j
+@Component
+public class MercadoPagoWebhookValidator {
+
+    @Value("${mercadopago.webhook-secret}")
+    private String webhookSecret;
+
+    public boolean isValid(String xSignature, String xRequestId, String dataId) {
+        try{
+            if(xSignature == null || xSignature.isBlank()) {
+                log.warn("x-signature ausente no Weebhook MP. requestId={}", xRequestId);
+                return false;
+            }
+
+            String ts = null;
+            String v1 = null;
+            
+            for (String part : xSignature.split(",")) {
+                String[] kv = part.trim().split("=", 2);
+                if (kv.length == 2) {
+                    if ("ts".equals(kv[0])) ts = kv[1];
+                    if ("v1".equals(kv[0])) v1 = kv[1];
+                }
+            }
+
+            if (ts == null || v1 == null) {
+                log.warn("x-signature malformada no Weebhook MP. requestId={}", xRequestId);
+                return false;
+            }
+
+            String manifest = "id" + dataId + ";requestId" + xRequestId + ";ts" + ts + ";";
+
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(webhookSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            byte[] hashBytes = mac.doFinal(manifest.getBytes(StandardCharsets.UTF_8));
+
+            String computed = HexFormat.of().formatHex(hashBytes);
+            boolean valid = computed.equals(v1);
+
+            if (!valid) {
+                log.warn("Validação falhou para webhook do Mercado Pago. requestId={}", xRequestId);
+            }
+            return valid;
+
+        } catch (Exception e) {
+            log.error("Erro ao validar webhook do Mercado Pago. requestId={}", xRequestId, e);
+            return false;
+        
+        }
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
@@ -17,6 +17,10 @@ public class MercadoPagoWebhookValidator {
     private String webhookSecret;
 
     public boolean isValid(String xSignature, String xRequestId, String dataId) {
+
+        log.info("Validando webhook. xSignature={}, webhookSecret presente={}", 
+            xSignature, webhookSecret != null && !webhookSecret.equals("webhook-placeholder"));
+
         try{
             if(xSignature == null || xSignature.isBlank()) {
                 log.warn("x-signature ausente no Weebhook MP. requestId={}", xRequestId);
@@ -39,7 +43,7 @@ public class MercadoPagoWebhookValidator {
                 return false;
             }
 
-            String manifest = "id" + dataId + ";requestId" + xRequestId + ";ts" + ts + ";";
+            String manifest = "id:" + dataId + ";request-id:" + xRequestId + ";ts:" + ts + ";";
 
             Mac mac = Mac.getInstance("HmacSHA256");
             mac.init(new SecretKeySpec(webhookSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
@@ -17,10 +17,6 @@ public class MercadoPagoWebhookValidator {
     private String webhookSecret;
 
     public boolean isValid(String xSignature, String xRequestId, String dataId) {
-
-        log.info("Validando webhook. xSignature={}, webhookSecret presente={}", 
-            xSignature, webhookSecret != null && !webhookSecret.equals("webhook-placeholder"));
-
         try{
             if(xSignature == null || xSignature.isBlank()) {
                 log.warn("x-signature ausente no Weebhook MP. requestId={}", xRequestId);

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/resources/application-docker.properties
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/resources/application-docker.properties
@@ -36,3 +36,5 @@ management.endpoint.health.show-details=always
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080/realms/mybuddy
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://mybuddy-keycloak:8080/realms/mybuddy/protocol/openid-connect/certs
 spring.security.oauth2.client.provider.keycloak.issuer-uri=http://mybuddy-keycloak:8080/realms/mybuddy
+
+mercadopago.webhook-secret=${MERCADOPAGO_WEBHOOK_SECRET:webhook-placeholder}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/resources/application.properties
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/resources/application.properties
@@ -24,11 +24,16 @@ spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.Ph
 
 spring.jpa.properties.hibernate.format_sql=true
 
+# JWT
 mybuddy.app.jwtSecret=${JWT_SECRET:not-used}
 mybuddy.app.jwtExpirationMs=86400000
 
+# Log
 logging.level.org.springframework.security=INFO
 logging.level.org.springframework.web.servlet.DispatcherServlet=INFO
+
+# Mercado Pago
 mercadopago.access-token=${MERCADOPAGO_ACCESS_TOKEN:token-placeholder}
 mercadopago.public-key=${MERCADOPAGO_PUBLIC_KEY:key-placeholder}
 mercadopago.secret-key=${MERCADOPAGO_SECRET_KEY:secret-placeholder}
+mercadopago.webhook-secret=${MERCADOPAGO_WEBHOOK_SECRET:webhook-placeholder}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,28 @@
 services:
 
+# ── ngrok: túnel para webhook do MP ──────────────────────
+  ngrok:
+    image: ngrok/ngrok:latest
+    container_name: mybuddy-ngrok
+    restart: unless-stopped
+    command: http mybuddy-backend:8081 --log=stdout
+    environment:
+      NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN}
+    ports:
+      - "4040:4040"
+    depends_on:
+      backend:
+        condition: service_healthy
+    networks:
+      - mybuddy-network
+    
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:4040/api/tunnels | grep -q 'public_url'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
   # ── MY-239: MongoDB ──────────────────────────────────────
   mongodb:
     image: mongo:7.0


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-207](https://ederpontes2014.atlassian.net/browse/MY-207)
- **Tipo:** Feature

---

## O que foi feito?

Implementação da validação de assinatura `x-signature` no endpoint de webhook do Mercado Pago. O MP assina cada notificação com HMAC-SHA256 usando um secret configurado no painel de webhooks. A validação garante que apenas notificações legítimas do MP são processadas.

**Fluxo de validação:**
1. MP envia `x-signature` no header no formato `ts=TIMESTAMP,v1=HASH`
2. O `MercadoPagoWebhookValidator` extrai `ts` e `v1`
3. Monta o manifest: `id:{dataId};request-id:{xRequestId};ts:{ts};`
4. Calcula HMAC-SHA256 do manifest com o `MERCADOPAGO_WEBHOOK_SECRET`
5. Compara o hash calculado com o `v1` recebido
6. Se inválido → retorna `401`; se válido → processa o evento

---

## Arquivos criados/modificados

- `Util/MercadoPagoWebhookValidator.java` — componente de validação HMAC-SHA256
- `Controller/PaymentController.java` — webhook atualizado com validação
- `application.properties` — adicionado `mercadopago.webhook-secret`
- `.env` e `docker-compose.yml` — adicionado `MERCADOPAGO_WEBHOOK_SECRET` no backend e ngrok container

---

## Escopo das mudanças

- [x] `backend` — Java / Spring Boot
- [x] `infra` — Docker Compose (ngrok + env vars)

---

## Checklist de Testes

- [x] Projeto compila sem erros
- [x] Spring Boot sobe localmente e via Docker Compose sem erros
- [x] Webhook sem `x-signature` retorna `401`
- [x] Webhook com assinatura válida via painel MP retorna `200`
- [ ] Teste E2E do fluxo completo com pagamento real em sandbox (MY-214)

---

## Checklist de Code Review

- [x] Secret nunca logado ou exposto
- [x] Webhook responde `401` para assinaturas inválidas
- [x] Webhook responde `200` imediatamente antes de processar
- [x] Manifest no formato correto: `id:{dataId};request-id:{xRequestId};ts:{ts};`
- [x] `HexFormat.of().formatHex()` compatível com Java 21

---

## Notas para o Revisor

- O secret está em `MERCADOPAGO_WEBHOOK_SECRET` no `.env` — nunca hardcoded
- O `MercadoPagoWebhookValidator` usa `javax.crypto.Mac` nativo do Java, sem dependência nova
- Container ngrok adicionado no `docker-compose.yml` para facilitar testes locais de webhook — acesse `http://localhost:4040` para ver a URL pública gerada
- O listener assíncrono que processa o evento após validação foi implementado na MY-209

---

## Como testar

```
1. Subir o docker compose completo
2. Acessar http://localhost:4040 e copiar a URL pública do ngrok
3. Configurar URL no painel MP: https://{url-ngrok}/api/payments/webhook
4. Clicar em "Simular notificação" no painel MP
5. Verificar nos logs do backend:
   - "Webhook MP recebido" → notificação chegou
   - "Webhook rejeitado — assinatura inválida" → validação funcionando
   - "200 OK" → fluxo completo ok
```

[MY-207]: https://ederpontes2014.atlassian.net/browse/MY-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ