### PR TITLE
Feature/MYB-285

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Controller/PetControllerTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Controller/PetControllerTest.java
@@ -3,26 +3,31 @@ package com.Mybuddy.Myb.Controller;
 import com.Mybuddy.Myb.Config.SecurityConfig;
 import com.Mybuddy.Myb.DTO.PetRequestDTO;
 import com.Mybuddy.Myb.DTO.PetResponse;
+import com.Mybuddy.Myb.Model.StatusAdocao;
 import com.Mybuddy.Myb.Security.JwtAuthConverter;
 import com.Mybuddy.Myb.Service.FotoPetService;
 import com.Mybuddy.Myb.Service.PetService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(PetController.class)
 @Import({SecurityConfig.class, JwtAuthConverter.class})
@@ -31,82 +36,206 @@ class PetControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private PetService petService;
 
-    @MockBean
+    @MockitoBean
     private FotoPetService fotoPetService;
 
+    private PetResponse petResponse;
+
+    private static final String PET_JSON = """
+            {
+                "nome": "Rex",
+                "especie": "CAO",
+                "raca": "Labrador",
+                "idade": 2,
+                "porte": "GRANDE",
+                "cor": "Amarelo",
+                "sexo": "M",
+                "castrado": true,
+                "vacinado": true,
+                "microchipado": false,
+                "statusAdocao": "DISPONIVEL",
+                "organizacaoId": 1
+            }
+            """;
+
+    @BeforeEach
+    void setUp() {
+        petResponse = new PetResponse(
+                1L, "Rex", "CAO", "Labrador", 2, "GRANDE", "Amarelo",
+                null, "M", List.of(), "Disponível para Adoção",
+                StatusAdocao.DISPONIVEL, "ONG Teste", 1L,
+                false, true, true, null, null
+        );
+    }
+
+    // ===================== GET /api/pets =====================
+
     @Test
-    void deveRetornar401QuandoSemToken() throws Exception {
+    void deveRetornar401QuandoBuscarPetsSemToken() throws Exception {
         mockMvc.perform(get("/api/pets"))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void deveRetornar200QuandoAutenticado() throws Exception {
+    void deveRetornar200QuandoBuscarPetsAutenticado() throws Exception {
+        when(petService.buscarComFiltrosDTO(any(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(petResponse)));
+
+        mockMvc.perform(get("/api/pets")
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].nome").value("Rex"));
+    }
+
+    @Test
+    void deveRetornar200ComListaVaziaQuandoNaoHouverPets() throws Exception {
         when(petService.buscarComFiltrosDTO(any(), any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of()));
 
         mockMvc.perform(get("/api/pets")
                         .with(jwt().authorities(() -> "ROLE_USER")))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isEmpty());
+    }
+
+    // ===================== GET /api/pets/{id} =====================
+
+    @Test
+    void deveRetornar401QuandoBuscarPetPorIdSemToken() throws Exception {
+        mockMvc.perform(get("/api/pets/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deveRetornar200QuandoBuscarPetPorIdExistente() throws Exception {
+        when(petService.buscarPetPorIdDTO(1L)).thenReturn(Optional.of(petResponse));
+
+        mockMvc.perform(get("/api/pets/1")
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.nome").value("Rex"))
+                .andExpect(jsonPath("$.especie").value("CAO"));
+    }
+
+    @Test
+    void deveRetornar404QuandoBuscarPetPorIdInexistente() throws Exception {
+        when(petService.buscarPetPorIdDTO(99L)).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/pets/99")
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isNotFound());
+    }
+
+    // ===================== POST /api/pets =====================
+
+    @Test
+    void deveRetornar401QuandoCriarPetSemToken() throws Exception {
+        mockMvc.perform(post("/api/pets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PET_JSON))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
     void deveRetornar403QuandoUserTentaCriarPet() throws Exception {
         mockMvc.perform(post("/api/pets")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                    "nome": "Rex",
-                                    "especie": "CAO",
-                                    "raca": "Labrador",
-                                    "idade": 2,
-                                    "porte": "GRANDE",
-                                    "cor": "Amarelo",
-                                    "sexo": "M",
-                                    "castrado": true,
-                                    "vacinado": true,
-                                    "microchipado": false,
-                                    "statusAdocao": "DISPONIVEL",
-                                    "organizacaoId": 1
-                                }
-                                """)
+                        .content(PET_JSON)
                         .with(jwt().authorities(() -> "ROLE_USER")))
                 .andExpect(status().isForbidden());
     }
 
     @Test
     void deveRetornar201QuandoOngCriaPet() throws Exception {
-        PetResponse petResponse = new PetResponse(
-                1L, "Rex", "CAO", "Labrador", 2, "GRANDE", "Amarelo",
-                null, "M", List.of(), "Em Adoção", null, "ONG Teste",
-                1L, false, true, true, null, null
-        );
-
         when(petService.criarPet(any(PetRequestDTO.class))).thenReturn(petResponse);
 
         mockMvc.perform(post("/api/pets")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                    "nome": "Rex",
-                                    "especie": "CAO",
-                                    "raca": "Labrador",
-                                    "idade": 2,
-                                    "porte": "GRANDE",
-                                    "cor": "Amarelo",
-                                    "sexo": "M",
-                                    "castrado": true,
-                                    "vacinado": true,
-                                    "microchipado": false,
-                                    "statusAdocao": "DISPONIVEL",
-                                    "organizacaoId": 1
-                                }
-                                """)
+                        .content(PET_JSON)
                         .with(jwt().authorities(() -> "ROLE_ONG")))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.nome").value("Rex"))
+                .andExpect(header().string("Location", "/api/pets/1"));
+    }
+
+    @Test
+    void deveRetornar201QuandoAdminCriaPet() throws Exception {
+        when(petService.criarPet(any(PetRequestDTO.class))).thenReturn(petResponse);
+
+        mockMvc.perform(post("/api/pets")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PET_JSON)
+                        .with(jwt().authorities(() -> "ROLE_ADMIN")))
                 .andExpect(status().isCreated());
+    }
+
+    // ===================== PUT /api/pets/{id} =====================
+
+    @Test
+    void deveRetornar401QuandoAtualizarPetSemToken() throws Exception {
+        mockMvc.perform(put("/api/pets/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PET_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deveRetornar403QuandoUserTentaAtualizarPet() throws Exception {
+        mockMvc.perform(put("/api/pets/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PET_JSON)
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deveRetornar200QuandoOngAtualizaPet() throws Exception {
+        when(petService.atualizarPet(eq(1L), any(PetRequestDTO.class))).thenReturn(petResponse);
+
+        mockMvc.perform(put("/api/pets/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PET_JSON)
+                        .with(jwt().authorities(() -> "ROLE_ONG")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nome").value("Rex"));
+    }
+
+    @Test
+    void deveRetornar200QuandoAdminAtualizaPet() throws Exception {
+        when(petService.atualizarPet(eq(1L), any(PetRequestDTO.class))).thenReturn(petResponse);
+
+        mockMvc.perform(put("/api/pets/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(PET_JSON)
+                        .with(jwt().authorities(() -> "ROLE_ADMIN")))
+                .andExpect(status().isOk());
+    }
+
+    // ===================== DELETE /api/pets/{id} =====================
+
+    @Test
+    void deveRetornar401QuandoDeletarPetSemToken() throws Exception {
+        mockMvc.perform(delete("/api/pets/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deveRetornar403QuandoUserTentaDeletarPet() throws Exception {
+        mockMvc.perform(delete("/api/pets/1")
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deveRetornar403QuandoOngTentaDeletarPet() throws Exception {
+        mockMvc.perform(delete("/api/pets/1")
+                        .with(jwt().authorities(() -> "ROLE_ONG")))
+                .andExpect(status().isForbidden());
     }
 
     @Test
@@ -114,11 +243,118 @@ class PetControllerTest {
         mockMvc.perform(delete("/api/pets/1")
                         .with(jwt().authorities(() -> "ROLE_ADMIN")))
                 .andExpect(status().isNoContent());
+
+        verify(petService, times(1)).deletarPet(1L);
+    }
+
+    // ===================== GET /api/pets/organizacao/{id} =====================
+
+    @Test
+    void deveRetornar401QuandoBuscarPetsPorOrganizacaoSemToken() throws Exception {
+        mockMvc.perform(get("/api/pets/organizacao/1"))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void deveRetornar403QuandoUserTentaDeletarPet() throws Exception {
-        mockMvc.perform(delete("/api/pets/1")
+    void deveRetornar403QuandoUserBuscaPetsPorOrganizacao() throws Exception {
+        mockMvc.perform(get("/api/pets/organizacao/1")
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deveRetornar200QuandoOngBuscaPetsPorOrganizacao() throws Exception {
+        when(petService.buscarPetsPorOrganizacaoId(1L)).thenReturn(List.of(petResponse));
+
+        mockMvc.perform(get("/api/pets/organizacao/1")
+                        .with(jwt()
+                                .authorities(() -> "ROLE_ONG")
+                                .jwt(jwt -> jwt.subject("keycloak-id-123"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].nome").value("Rex"))
+                .andExpect(jsonPath("$[0].organizacaoId").value(1));
+    }
+
+    @Test
+    void deveRetornar200QuandoAdminBuscaPetsPorOrganizacao() throws Exception {
+        when(petService.buscarPetsPorOrganizacaoId(1L)).thenReturn(List.of(petResponse));
+
+        mockMvc.perform(get("/api/pets/organizacao/1")
+                        .with(jwt()
+                                .authorities(() -> "ROLE_ADMIN")
+                                .jwt(jwt -> jwt.subject("keycloak-id-admin"))))
+                .andExpect(status().isOk());
+    }
+
+    // ===================== POST /api/pets/upload-image =====================
+
+    @Test
+    void deveRetornar401QuandoUploadImagemSemToken() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "foto.jpg", "image/jpeg", "conteudo".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/pets/upload-image").file(file))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void deveRetornar403QuandoUserTentaFazerUploadImagem() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "foto.jpg", "image/jpeg", "conteudo".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/pets/upload-image")
+                        .file(file)
+                        .with(jwt().authorities(() -> "ROLE_USER")))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deveRetornar200QuandoOngFazUploadImagem() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "foto.jpg", "image/jpeg", "conteudo".getBytes()
+        );
+
+        when(fotoPetService.storeFile(any())).thenReturn("foto.jpg");
+
+        mockMvc.perform(multipart("/api/pets/upload-image")
+                        .file(file)
+                        .with(jwt().authorities(() -> "ROLE_ONG")))
+                .andExpect(status().isOk())
+                .andExpect(content().string("foto.jpg"));
+    }
+
+    // ===================== POST /api/pets/upload-images =====================
+
+    @Test
+    void deveRetornar200QuandoOngFazUploadMultiplasImagens() throws Exception {
+        MockMultipartFile file1 = new MockMultipartFile(
+                "files", "foto1.jpg", "image/jpeg", "conteudo1".getBytes()
+        );
+        MockMultipartFile file2 = new MockMultipartFile(
+                "files", "foto2.jpg", "image/jpeg", "conteudo2".getBytes()
+        );
+
+        when(fotoPetService.storeFiles(any())).thenReturn(List.of("foto1.jpg", "foto2.jpg"));
+
+        mockMvc.perform(multipart("/api/pets/upload-images")
+                        .file(file1)
+                        .file(file2)
+                        .with(jwt().authorities(() -> "ROLE_ONG")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0]").value("foto1.jpg"))
+                .andExpect(jsonPath("$[1]").value("foto2.jpg"));
+    }
+
+    @Test
+    void deveRetornar403QuandoUserTentaFazerUploadMultiplasImagens() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "files", "foto.jpg", "image/jpeg", "conteudo".getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/pets/upload-images")
+                        .file(file)
                         .with(jwt().authorities(() -> "ROLE_USER")))
                 .andExpect(status().isForbidden());
     }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Repository/PetRepositoryTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Repository/PetRepositoryTest.java
@@ -1,0 +1,215 @@
+package com.Mybuddy.Myb.Repository;
+
+import com.Mybuddy.Myb.Model.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class PetRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    private Organizacao organizacao1;
+    private Organizacao organizacao2;
+    private Pet pet1;
+    private Pet pet2;
+    private Pet pet3;
+
+    @BeforeEach
+    void setUp() {
+        organizacao1 = Organizacao.builder()
+                .nomeFantasia("ONG Patinhas")
+                .emailContato("patinhas@email.com")
+                .cnpj("11.111.111/0001-11")
+                .endereco("Rua A, 123")
+                .telefoneContato("11999990001")
+                .build();
+
+        organizacao2 = Organizacao.builder()
+                .nomeFantasia("ONG Amigos dos Bichos")
+                .emailContato("amigos@email.com")
+                .cnpj("22.222.222/0002-22")
+                .endereco("Rua B, 456")
+                .telefoneContato("11999990002")
+                .build();
+
+        entityManager.persist(organizacao1);
+        entityManager.persist(organizacao2);
+
+        pet1 = new Pet("Rex", "Labrador", 2, Especie.CAO, Porte.GRANDE,
+                "Amarelo", null, "M", organizacao1,
+                false, true, true, "São Paulo", "SP");
+
+        pet2 = new Pet("Mia", "Siamês", 3, Especie.GATO, Porte.PEQUENO,
+                "Branco", null, "F", organizacao1,
+                false, true, false, "Campinas", "SP");
+
+        pet3 = new Pet("Bob", "Poodle", 1, Especie.CAO, Porte.PEQUENO,
+                "Preto", null, "M", organizacao2,
+                true, true, true, "Rio de Janeiro", "RJ");
+
+        entityManager.persist(pet1);
+        entityManager.persist(pet2);
+        entityManager.persist(pet3);
+        entityManager.flush();
+    }
+
+    // ===================== FIND BY ID =====================
+
+    @Test
+    void deveBuscarPetPorIdExistente() {
+        Optional<Pet> resultado = petRepository.findById(pet1.getId());
+
+        assertThat(resultado).isPresent();
+        assertThat(resultado.get().getNome()).isEqualTo("Rex");
+    }
+
+    @Test
+    void deveRetornarVazioAoBuscarPetPorIdInexistente() {
+        Optional<Pet> resultado = petRepository.findById(999L);
+
+        assertThat(resultado).isEmpty();
+    }
+
+    // ===================== FIND ALL =====================
+
+    @Test
+    void deveBuscarTodosPets() {
+        List<Pet> pets = petRepository.findAll();
+
+        assertThat(pets).hasSize(3);
+    }
+
+    // ===================== FIND BY ORGANIZACAO ID =====================
+
+    @Test
+    void deveBuscarPetsPorOrganizacaoId() {
+        List<Pet> pets = petRepository.findByOrganizacaoId(organizacao1.getId());
+
+        assertThat(pets).hasSize(2);
+        assertThat(pets).extracting(Pet::getNome)
+                .containsExactlyInAnyOrder("Rex", "Mia");
+    }
+
+    @Test
+    void deveBuscarPetsDaSegundaOrganizacao() {
+        List<Pet> pets = petRepository.findByOrganizacaoId(organizacao2.getId());
+
+        assertThat(pets).hasSize(1);
+        assertThat(pets.get(0).getNome()).isEqualTo("Bob");
+    }
+
+    @Test
+    void deveRetornarListaVaziaParaOrganizacaoSemPets() {
+        Organizacao organizacaoVazia = Organizacao.builder()
+                .nomeFantasia("ONG Vazia")
+                .emailContato("vazia@email.com")
+                .cnpj("33.333.333/0003-33")
+                .endereco("Rua C, 789")
+                .build();
+        entityManager.persist(organizacaoVazia);
+        entityManager.flush();
+
+        List<Pet> pets = petRepository.findByOrganizacaoId(organizacaoVazia.getId());
+
+        assertThat(pets).isEmpty();
+    }
+
+    @Test
+    void deveRetornarListaVaziaParaOrganizacaoInexistente() {
+        List<Pet> pets = petRepository.findByOrganizacaoId(999L);
+
+        assertThat(pets).isEmpty();
+    }
+
+    // ===================== SAVE =====================
+
+    @Test
+    void deveSalvarNovoPet() {
+        Pet novoPet = new Pet("Luna", "Vira-lata", 4, Especie.CAO, Porte.MEDIO,
+                "Caramelo", null, "F", organizacao1,
+                false, false, false, "Curitiba", "PR");
+
+        Pet salvo = petRepository.save(novoPet);
+
+        assertThat(salvo.getId()).isNotNull();
+        assertThat(salvo.getNome()).isEqualTo("Luna");
+        assertThat(salvo.getOrganizacao().getId()).isEqualTo(organizacao1.getId());
+    }
+
+    @Test
+    void deveSalvarPetComStatusDisponivelPorPadrao() {
+        Pet novoPet = new Pet("Toby", "Beagle", 2, Especie.CAO, Porte.MEDIO,
+                "Tricolor", null, "M", organizacao1,
+                false, true, true, "Belo Horizonte", "MG");
+
+        Pet salvo = petRepository.save(novoPet);
+
+        assertThat(salvo.getStatusAdocao()).isEqualTo(StatusAdocao.DISPONIVEL);
+    }
+
+    // ===================== UPDATE =====================
+
+    @Test
+    void deveAtualizarPet() {
+        pet1.setNome("Rex Atualizado");
+        pet1.setStatusAdocao(StatusAdocao.ADOTADO);
+        petRepository.save(pet1);
+        entityManager.flush();
+        entityManager.clear();
+
+        Optional<Pet> atualizado = petRepository.findById(pet1.getId());
+
+        assertThat(atualizado).isPresent();
+        assertThat(atualizado.get().getNome()).isEqualTo("Rex Atualizado");
+        assertThat(atualizado.get().getStatusAdocao()).isEqualTo(StatusAdocao.ADOTADO);
+    }
+
+    // ===================== DELETE =====================
+
+    @Test
+    void deveDeletarPet() {
+        petRepository.deleteById(pet1.getId());
+        entityManager.flush();
+
+        Optional<Pet> deletado = petRepository.findById(pet1.getId());
+
+        assertThat(deletado).isEmpty();
+    }
+
+    @Test
+    void deveManterOutrosPetsAoDeletarUm() {
+        petRepository.deleteById(pet1.getId());
+        entityManager.flush();
+
+        List<Pet> pets = petRepository.findAll();
+
+        assertThat(pets).hasSize(2);
+        assertThat(pets).extracting(Pet::getNome)
+                .containsExactlyInAnyOrder("Mia", "Bob");
+    }
+
+    @Test
+    void deveDeletarApenasPetsDaOrganizacaoCorreta() {
+        petRepository.deleteById(pet3.getId());
+        entityManager.flush();
+
+        List<Pet> petsOrg1 = petRepository.findByOrganizacaoId(organizacao1.getId());
+        List<Pet> petsOrg2 = petRepository.findByOrganizacaoId(organizacao2.getId());
+
+        assertThat(petsOrg1).hasSize(2);
+        assertThat(petsOrg2).isEmpty();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/PetServiceTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/PetServiceTest.java
@@ -1,0 +1,263 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.PetRequestDTO;
+import com.Mybuddy.Myb.DTO.PetResponse;
+import com.Mybuddy.Myb.Model.Organizacao;
+import com.Mybuddy.Myb.Model.Pet;
+import com.Mybuddy.Myb.Model.StatusAdocao;
+import com.Mybuddy.Myb.Repository.InteresseAdocaoRepository;
+import com.Mybuddy.Myb.Repository.OrganizacaoRepository;
+import com.Mybuddy.Myb.Repository.PetRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PetServiceTest {
+
+    @Mock
+    private PetRepository petRepository;
+
+    @Mock
+    private InteresseAdocaoRepository interesseRepo;
+
+    @Mock
+    private OrganizacaoRepository organizacaoRepository;
+
+    @InjectMocks
+    private PetService petService;
+
+    private Organizacao organizacao;
+    private Pet pet;
+    private PetRequestDTO petRequestDTO;
+
+    @BeforeEach
+    void setUp() {
+        organizacao = new Organizacao();
+        organizacao.setId(1L);
+        organizacao.setNomeFantasia("ONG Teste");
+
+        pet = new Pet();
+        pet.setId(1L);
+        pet.setNome("Rex");
+        pet.setOrganizacao(organizacao);
+        pet.setStatusAdocao(StatusAdocao.DISPONIVEL);
+
+        petRequestDTO = new PetRequestDTO();
+        petRequestDTO.setNome("Rex");
+        petRequestDTO.setOrganizacaoId(1L);
+        petRequestDTO.setStatusAdocao(StatusAdocao.DISPONIVEL);
+    }
+
+    // ===================== CRIAR PET =====================
+
+    @Test
+    void deveCriarPetComSucesso() {
+        when(organizacaoRepository.findById(1L)).thenReturn(Optional.of(organizacao));
+        when(petRepository.save(any(Pet.class))).thenReturn(pet);
+
+        PetResponse response = petService.criarPet(petRequestDTO);
+
+        assertThat(response).isNotNull();
+        assertThat(response.nome()).isEqualTo("Rex");
+        verify(petRepository, times(1)).save(any(Pet.class));
+    }
+
+    @Test
+    void deveLancarExcecaoAoCriarPetSemOrganizacaoId() {
+        petRequestDTO.setOrganizacaoId(null);
+
+        assertThatThrownBy(() -> petService.criarPet(petRequestDTO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ID da organização é obrigatório");
+    }
+
+    @Test
+    void deveLancarExcecaoAoCriarPetComOrganizacaoInexistente() {
+        when(organizacaoRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> petService.criarPet(petRequestDTO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Organização não encontrada");
+    }
+
+    @Test
+    void deveCriarPetComStatusDisponivelPorPadraoQuandoStatusNulo() {
+        petRequestDTO.setStatusAdocao(null);
+
+        when(organizacaoRepository.findById(1L)).thenReturn(Optional.of(organizacao));
+        when(petRepository.save(any(Pet.class))).thenAnswer(invocation -> {
+            Pet p = invocation.getArgument(0);
+            p.setId(1L);
+            p.setOrganizacao(organizacao);
+            return p;
+        });
+
+        PetResponse response = petService.criarPet(petRequestDTO);
+
+        assertThat(response.statusAdocao()).isEqualTo(StatusAdocao.DISPONIVEL);
+    }
+
+    // ===================== BUSCAR PETS =====================
+
+    @Test
+    void deveBuscarTodosPets() {
+        when(petRepository.findAll()).thenReturn(List.of(pet));
+
+        List<Pet> pets = petService.buscarTodosPets();
+
+        assertThat(pets).hasSize(1);
+        assertThat(pets.get(0).getNome()).isEqualTo("Rex");
+    }
+
+    @Test
+    void deveBuscarTodosPetsRetornarListaVaziaQuandoNaoHouverPets() {
+        when(petRepository.findAll()).thenReturn(List.of());
+
+        List<Pet> pets = petService.buscarTodosPets();
+
+        assertThat(pets).isEmpty();
+    }
+
+    @Test
+    void deveBuscarPetPorIdComSucesso() {
+        when(petRepository.findById(1L)).thenReturn(Optional.of(pet));
+
+        Optional<Pet> resultado = petService.buscarPetPorId(1L);
+
+        assertThat(resultado).isPresent();
+        assertThat(resultado.get().getId()).isEqualTo(1L);
+    }
+
+    @Test
+    void deveBuscarPetPorIdRetornarVazioQuandoNaoEncontrado() {
+        when(petRepository.findById(99L)).thenReturn(Optional.empty());
+
+        Optional<Pet> resultado = petService.buscarPetPorId(99L);
+
+        assertThat(resultado).isEmpty();
+    }
+
+    @Test
+    void deveBuscarPetPorIdDTOComSucesso() {
+        when(petRepository.findById(1L)).thenReturn(Optional.of(pet));
+
+        Optional<PetResponse> resultado = petService.buscarPetPorIdDTO(1L);
+
+        assertThat(resultado).isPresent();
+        assertThat(resultado.get().nome()).isEqualTo("Rex");
+    }
+
+    @Test
+    void deveBuscarPetsPorOrganizacaoId() {
+        when(petRepository.findByOrganizacaoId(1L)).thenReturn(List.of(pet));
+
+        List<PetResponse> pets = petService.buscarPetsPorOrganizacaoId(1L);
+
+        assertThat(pets).hasSize(1);
+        verify(petRepository, times(1)).findByOrganizacaoId(1L);
+    }
+
+    // ===================== ATUALIZAR PET =====================
+
+    @Test
+    void deveAtualizarPetComSucesso() {
+        petRequestDTO.setNome("Max");
+
+        when(petRepository.findById(1L)).thenReturn(Optional.of(pet));
+        when(petRepository.save(any(Pet.class))).thenReturn(pet);
+
+        PetResponse response = petService.atualizarPet(1L, petRequestDTO);
+
+        assertThat(response).isNotNull();
+        verify(petRepository, times(1)).save(any(Pet.class));
+    }
+
+    @Test
+    void deveLancarExcecaoAoAtualizarPetInexistente() {
+        when(petRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> petService.atualizarPet(99L, petRequestDTO))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Pet com ID 99 não encontrado");
+    }
+
+    @Test
+    void deveLancarExcecaoAoAtualizarPetSemOrganizacaoId() {
+        petRequestDTO.setOrganizacaoId(null);
+
+        when(petRepository.findById(1L)).thenReturn(Optional.of(pet));
+
+        assertThatThrownBy(() -> petService.atualizarPet(1L, petRequestDTO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ID da organização é obrigatório");
+    }
+
+    @Test
+    void deveLancarExcecaoAoAtualizarPetComNovaOrganizacaoInexistente() {
+        petRequestDTO.setOrganizacaoId(99L);
+
+        Pet petSemOrg = new Pet();
+        petSemOrg.setId(1L);
+        petSemOrg.setOrganizacao(null);
+
+        when(petRepository.findById(1L)).thenReturn(Optional.of(petSemOrg));
+        when(organizacaoRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> petService.atualizarPet(1L, petRequestDTO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Nova organização não encontrada");
+    }
+
+    // ===================== DELETAR PET =====================
+
+    @Test
+    void deveDeletarPetComSucesso() {
+        when(petRepository.findById(1L)).thenReturn(Optional.of(pet));
+        when(interesseRepo.countByPetId(1L)).thenReturn(0L);
+
+        petService.deletarPet(1L);
+
+        verify(petRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void deveLancarExcecaoAoDeletarPetInexistente() {
+        when(petRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> petService.deletarPet(99L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Pet com ID 99 não encontrado");
+    }
+
+    @Test
+    void deveLancarExcecaoAoDeletarPetAdotado() {
+        pet.setStatusAdocao(StatusAdocao.ADOTADO);
+        when(petRepository.findById(1L)).thenReturn(Optional.of(pet));
+
+        assertThatThrownBy(() -> petService.deletarPet(1L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Não é possível excluir pet já adotado");
+    }
+
+    @Test
+    void deveLancarExcecaoAoDeletarPetComInteressesRegistrados() {
+        when(petRepository.findById(1L)).thenReturn(Optional.of(pet));
+        when(interesseRepo.countByPetId(1L)).thenReturn(3L);
+
+        assertThatThrownBy(() -> petService.deletarPet(1L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("interesses registrados");
+    }
+}


### PR DESCRIPTION
## Task Jira
- **Card:** [MYB-285](https://mybuddy.atlassian.net/browse/MYB-285)
- **Tipo:** Chore
---
## O que foi feito?
Implementa testes de repositório com `@DataJpaTest` para o `PetRepository`, cobrindo as operações de CRUD e a query customizada `findByOrganizacaoId`. Total de 14 testes utilizando `TestEntityManager` e banco H2 em memória.

---
## Escopo das mudanças
- [x] `backend` — Java / Spring Boot
- [ ] `frontend` — Angular
- [ ] `mobile` — Flutter
- [ ] `infra` — Docker / CI / configurações
---
## Checklist de Testes
- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [x] Testes automatizados foram criados ou atualizados (se aplicável)
---
## Checklist de Code Review
- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e são reversíveis
---
## Notas para o Revisor
- Arquivo criado em `src/test/java/com/Mybuddy/Myb/Repository/PetRepositoryTest.java`
- Utiliza `@DataJpaTest` que sobe apenas a camada JPA com banco H2 em memória — sem Spring completo, sem segurança, execução rápida
- `TestEntityManager` é usado para persistir dados de teste diretamente, sem passar pelo service
- Dois cenários de organizações são montados no `@BeforeEach` com 3 pets distribuídos entre elas
- Cenários cobertos:
  - **findById**: encontrado, não encontrado
  - **findAll**: retorna todos os pets
  - **findByOrganizacaoId**: org com 2 pets, org com 1 pet, org sem pets, org inexistente
  - **save**: novo pet persistido, status padrão DISPONIVEL
  - **update**: atualiza nome e status, verifica persistência após flush/clear
  - **delete**: deleta por ID, mantém outros pets, deleta apenas da organização correta
---
## Como testar
```
1. Acessar o módulo Back End
2. Executar: ./mvnw test -Dtest=PetRepositoryTest
3. Verificar que todos os 14 testes passam sem erros
```