### PR TITLE
feat [MY-235]: Integrar Payment Brick como segunda opção na tela

### DIFF
--- a/Front End - Angular/mybuddy/src/app/features/checkout/pagamento/pagamento.html
+++ b/Front End - Angular/mybuddy/src/app/features/checkout/pagamento/pagamento.html
@@ -1,5 +1,6 @@
 <div class="pagamento-container">
   <div class="pagamento-card">
+
     <div class="pagamento-header">
       <button class="btn-voltar" (click)="voltar()">
         <span class="material-icons">arrow_back</span>
@@ -11,12 +12,10 @@
       <div class="resumo-icon">
         <span class="material-icons">pets</span>
       </div>
-
       <div class="resumo-info">
         <h3>{{ petNome() || 'Doação MyBuddy' }}</h3>
         <p class="caption">{{ petNome() ? 'Taxa de adoção' : 'Contribuição para a plataforma' }}</p>
       </div>
-
       <div class="resumo-valor">
         <span class="valor">R$ {{ amount().toFixed(2) }}</span>
       </div>
@@ -53,5 +52,29 @@
         Pagar com Mercado Pago
       }
     </button>
+
+    <div class="pagamento-divider"></div>
+
+    <p class="ou-texto">ou</p>
+
+    <button
+      class="btn-brick"
+      (click)="abrirPaymentBrick()"
+      [disabled]="brickLoading()">
+      @if (brickLoading()) {
+        <span class="material-icons">hourglass_empty</span>
+        Carregando...
+      } @else {
+        <span class="material-icons">credit_card</span>
+        Pagar no site
+      }
+    </button>
+
+    @if (showBrick()) {
+      <div class="brick-container">
+        <div id="wallet-brick"></div>
+      </div>
+    }
+
   </div>
 </div>

--- a/Front End - Angular/mybuddy/src/app/features/checkout/pagamento/pagamento.scss
+++ b/Front End - Angular/mybuddy/src/app/features/checkout/pagamento/pagamento.scss
@@ -141,12 +141,38 @@
   gap: var(--spacing-xs);
   transition: opacity 0.2s;
 
-  &:hover:not(:disabled) {
-    opacity: 0.9;
-  }
+  &:hover:not(:disabled) { opacity: 0.9; }
+  &:disabled { opacity: 0.6; cursor: not-allowed; }
+}
 
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
+.ou-texto {
+  text-align: center;
+  color: var(--text-color-secondary);
+  margin: var(--spacing-sm) 0;
+  font-size: var(--font-size-sm);
+}
+
+.btn-brick {
+  width: 100%;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: transparent;
+  color: var(--text-color);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-md);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  margin-bottom: var(--spacing-sm);
+  transition: background 0.2s;
+
+  &:hover:not(:disabled) { background: var(--surface-ground); }
+  &:disabled { opacity: 0.6; cursor: not-allowed; }
+}
+
+.brick-container {
+  margin-top: var(--spacing-md);
+  min-height: 100px;
 }

--- a/Front End - Angular/mybuddy/src/app/features/checkout/pagamento/pagamento.ts
+++ b/Front End - Angular/mybuddy/src/app/features/checkout/pagamento/pagamento.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { PaymentService, PaymentRequest } from '../../../core/services/PaymentService';
+import { MercadoPagoService } from '../../../core/services/mercadopago.service';
 import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
@@ -9,10 +10,9 @@ import { ActivatedRoute, Router } from '@angular/router';
   templateUrl: './pagamento.html',
   styleUrl: './pagamento.scss',
 })
-
 export class Pagamento implements OnInit {
-
   private paymentService = inject(PaymentService);
+  private mpService = inject(MercadoPagoService);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
 
@@ -21,6 +21,9 @@ export class Pagamento implements OnInit {
   amount = signal<number>(50);
   loading = signal<boolean>(false);
   error = signal<string | null>(null);
+  preferenceId = signal<string | null>(null);
+  showBrick = signal<boolean>(false);
+  brickLoading = signal<boolean>(false);
 
   ngOnInit(): void {
     const petIdParam = this.route.snapshot.queryParamMap.get('petId');
@@ -50,6 +53,51 @@ export class Pagamento implements OnInit {
         this.error.set('Ocorreu um erro ao processar o pagamento.');
         this.loading.set(false);
         console.error('Payment error:', err);
+      },
+    });
+  }
+
+  async abrirPaymentBrick(): Promise<void> {
+    if (this.preferenceId()) {
+      this.showBrick.set(true);
+      await this.renderBrick(this.preferenceId()!);
+      return;
+    }
+
+    this.brickLoading.set(true);
+    this.error.set(null);
+
+    const request: PaymentRequest = {
+      petId: this.petId() ?? undefined,
+      amount: this.amount(),
+      description: this.petNome() ? `Adoção - ${this.petNome()}` : 'Doação MyBuddy',
+    };
+
+    this.paymentService.createPayment(request).subscribe({
+      next: async (response) => {
+        this.preferenceId.set(response.mpPreferenceId);
+        this.showBrick.set(true);
+        await this.renderBrick(response.mpPreferenceId);
+        this.brickLoading.set(false);
+      },
+      error: (err) => {
+        this.error.set('Erro ao inicializar o formulário de pagamento.');
+        this.brickLoading.set(false);
+        console.error(err);
+      },
+    });
+  }
+
+  private async renderBrick(preferenceId: string): Promise<void> {
+    await this.mpService.initialize();
+    const mp = this.mpService.getInstance();
+    if (!mp) return;
+
+    const bricksBuilder = mp.bricks();
+    await bricksBuilder.create('wallet', 'wallet-brick', {
+      initialization: { preferenceId },
+      customization: {
+        texts: { valueProp: 'smart_option' },
       },
     });
   }


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-235](https://ederpontes2014.atlassian.net/browse/MY-235)
- **Tipo:** Feature

---

## O que foi feito?

Integração do Payment Brick do Mercado Pago como segunda opção de pagamento na tela de checkout, mantendo o Checkout Pro como opção principal.

**Duas opções disponíveis:**
- **"Pagar com Mercado Pago"** → redireciona pro Checkout Pro (fluxo existente)
- **"Pagar no site"** → renderiza o Wallet Brick inline via SDK do MP

**Fluxo do Brick:**
1. Usuário clica em "Pagar no site"
2. Frontend chama `POST /api/payments/create` para criar a preferência
3. `preferenceId` retornado é usado para inicializar o Wallet Brick
4. `preferenceId` cacheado em signal — evita chamada duplicada ao backend se o usuário fechar e reabrir o Brick
5. Brick renderizado via `mp.bricks().create('wallet', 'wallet-brick', { initialization: { preferenceId } })`

---

## Arquivos criados/modificados

- `features/checkout/pagamento/pagamento.ts` — adicionado `abrirPaymentBrick()`, `renderBrick()` e signals de controle do Brick
- `features/checkout/pagamento/pagamento.html` — adicionado divider, texto "ou", botão "Pagar no site" e container do Brick dentro do card
- `features/checkout/pagamento/pagamento.scss` — corrigido aninhamento de estilos, adicionado `.ou-texto`, `.btn-brick` e `.brick-container` no nível raiz

---

## Escopo das mudanças

- [x] `frontend` — Angular

---

## Checklist de Testes

- [x] Build compila sem erros
- [x] Layout correto — botão "Pagar no site" dentro do card
- [x] Botão "Pagar no site" visível e clicável
- [x] SDK do MP carregado via `MercadoPagoService`
- [x] Brick tenta inicializar ao clicar no botão
- [ ] Brick renderiza completamente — **bloqueado por autenticação**

---

## Bloqueio — Por que o fluxo completo não foi testado

O botão "Pagar no site" depende de `POST /api/payments/create` para criar a preferência no backend antes de inicializar o Brick. Esse endpoint exige autenticação via JWT.

O projeto possui dois sistemas de autenticação coexistindo no frontend:
1. **Login com credentials** (`loginWithCredentials`) — salva token em cookie `mybuddy_session`
2. **Keycloak SDK** (`keycloak-angular`) — gerencia estado via redirect OAuth

O `authInterceptor` tenta injetar o token do cookie, mas após o login o Keycloak SDK interfere no ciclo de vida e o cookie não persiste entre navegações — resultando em `401 Unauthorized` em todas as chamadas ao backend.

**Decisão técnica pendente para o time:** escolher um único fluxo de autenticação antes de testar o fluxo completo de pagamento.

---

## Notas para o Revisor

- O `.ou-texto`, `.btn-brick` e `.brick-container` estavam incorretamente aninhados dentro de `.btn-pagar` no SCSS — corrigido nesta PR
- O `AfterViewInit` foi removido do import do `pagamento.ts` pois não era utilizado
- **Atenção:** quando a PR #132 do Eder for mergeada, vai gerar conflito em `pagamento.ts`, `pagamento.html` e `pagamento.scss`

[MY-235]: https://ederpontes2014.atlassian.net/browse/MY-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ