### PR TITLE
Feature/my 287 verificar relatorio jacoco

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/pom.xml
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/pom.xml
@@ -146,6 +146,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>mysql</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
+        <dependency>
             <groupId>com.github.dasniko</groupId>
             <artifactId>testcontainers-keycloak</artifactId>
             <version>3.4.0</version>

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/Interesseadocaoservicetest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/Interesseadocaoservicetest.java
@@ -62,7 +62,7 @@ class InteresseAdocaoServiceTest {
     // ===================== MANIFESTAR INTERESSE =====================
 
     @Test
-    void deveManifestарInteresseComSucesso() {
+    void deveManifestrarInteresseComSucesso() {
         when(usuarioRepo.findById(1L)).thenReturn(Optional.of(usuario));
         when(petRepo.findById(1L)).thenReturn(Optional.of(pet));
         when(interesseRepo.existsByUsuarioAndPet(usuario, pet)).thenReturn(false);

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/Interesseadocaoservicetest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/Interesseadocaoservicetest.java
@@ -1,0 +1,181 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.InteresseResponse;
+import com.Mybuddy.Myb.Model.*;
+import com.Mybuddy.Myb.Repository.InteresseAdocaoRepository;
+import com.Mybuddy.Myb.Repository.PetRepository;
+import com.Mybuddy.Myb.Repository.UsuarioRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InteresseAdocaoServiceTest {
+
+    @Mock
+    private InteresseAdocaoRepository interesseRepo;
+
+    @Mock
+    private UsuarioRepository usuarioRepo;
+
+    @Mock
+    private PetRepository petRepo;
+
+    @InjectMocks
+    private InteresseAdocaoService interesseAdocaoService;
+
+    private Usuario usuario;
+    private Pet pet;
+    private InteresseAdocao interesse;
+
+    @BeforeEach
+    void setUp() {
+        usuario = new Usuario();
+        usuario.setId(1L);
+        usuario.setNome("João");
+        usuario.setEmail("joao@email.com");
+
+        pet = new Pet();
+        pet.setId(1L);
+        pet.setNome("Rex");
+        pet.setStatusAdocao(StatusAdocao.DISPONIVEL);
+
+        interesse = new InteresseAdocao();
+        interesse.setId(1L);
+        interesse.setUsuario(usuario);
+        interesse.setPet(pet);
+        interesse.setMensagem("Quero adotar!");
+        interesse.setStatus(StatusInteresse.PENDENTE);
+    }
+
+    // ===================== MANIFESTAR INTERESSE =====================
+
+    @Test
+    void deveManifestарInteresseComSucesso() {
+        when(usuarioRepo.findById(1L)).thenReturn(Optional.of(usuario));
+        when(petRepo.findById(1L)).thenReturn(Optional.of(pet));
+        when(interesseRepo.existsByUsuarioAndPet(usuario, pet)).thenReturn(false);
+        when(interesseRepo.save(any(InteresseAdocao.class))).thenReturn(interesse);
+
+        InteresseResponse result = interesseAdocaoService.manifestarInteresse(1L, 1L, "Quero adotar!");
+
+        assertThat(result).isNotNull();
+        verify(interesseRepo, times(1)).save(any(InteresseAdocao.class));
+    }
+
+    @Test
+    void deveLancarExcecaoAoManifestarInteresseComUsuarioInexistente() {
+        when(usuarioRepo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(99L, 1L, "mensagem"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Usuário não encontrado: 99");
+    }
+
+    @Test
+    void deveLancarExcecaoAoManifestarInteresseComPetInexistente() {
+        when(usuarioRepo.findById(1L)).thenReturn(Optional.of(usuario));
+        when(petRepo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, 99L, "mensagem"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Pet não encontrado: 99");
+    }
+
+    @Test
+    void deveLancarExcecaoAoManifestarInteresseComPetIndisponivel() {
+        pet.setStatusAdocao(StatusAdocao.ADOTADO);
+
+        when(usuarioRepo.findById(1L)).thenReturn(Optional.of(usuario));
+        when(petRepo.findById(1L)).thenReturn(Optional.of(pet));
+
+        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, 1L, "mensagem"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Pet não está disponível para adoção");
+    }
+
+    @Test
+    void deveLancarExcecaoAoManifestarInteresseDuplicado() {
+        when(usuarioRepo.findById(1L)).thenReturn(Optional.of(usuario));
+        when(petRepo.findById(1L)).thenReturn(Optional.of(pet));
+        when(interesseRepo.existsByUsuarioAndPet(usuario, pet)).thenReturn(true);
+
+        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, 1L, "mensagem"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Você já manifestou interesse neste pet");
+    }
+
+    // ===================== ATUALIZAR STATUS =====================
+
+    @Test
+    void deveAtualizarStatusInteresseComSucesso() {
+        when(interesseRepo.findById(1L)).thenReturn(Optional.of(interesse));
+        when(interesseRepo.save(any(InteresseAdocao.class))).thenReturn(interesse);
+
+        InteresseResponse result = interesseAdocaoService.atualizarStatus(1L, StatusInteresse.APROVADO);
+
+        assertThat(result).isNotNull();
+        verify(interesseRepo, times(1)).save(any(InteresseAdocao.class));
+    }
+
+    @Test
+    void deveLancarExcecaoAoAtualizarStatusDeInteresseInexistente() {
+        when(interesseRepo.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> interesseAdocaoService.atualizarStatus(99L, StatusInteresse.APROVADO))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Interesse não encontrado: 99");
+    }
+
+    // ===================== LISTAR =====================
+
+    @Test
+    void deveListarInteressesPorUsuario() {
+        when(interesseRepo.findByUsuarioIdWithFetch(1L)).thenReturn(List.of(interesse));
+
+        List<InteresseResponse> result = interesseAdocaoService.listarPorUsuario(1L);
+
+        assertThat(result).hasSize(1);
+        verify(interesseRepo, times(1)).findByUsuarioIdWithFetch(1L);
+    }
+
+    @Test
+    void deveListarTodosInteresses() {
+        when(interesseRepo.findAllWithFetch()).thenReturn(List.of(interesse));
+
+        List<InteresseResponse> result = interesseAdocaoService.listarTodos();
+
+        assertThat(result).hasSize(1);
+        verify(interesseRepo, times(1)).findAllWithFetch();
+    }
+
+    @Test
+    void deveListarInteressesPorOrganizacao() {
+        when(interesseRepo.findByPetOrganizacaoIdWithFetch(1L)).thenReturn(List.of(interesse));
+
+        List<InteresseResponse> result = interesseAdocaoService.listarInteressesPorOrganizacao(1L);
+
+        assertThat(result).hasSize(1);
+        verify(interesseRepo, times(1)).findByPetOrganizacaoIdWithFetch(1L);
+    }
+
+    @Test
+    void deveRetornarListaVaziaQuandoNaoHouverInteressesPorUsuario() {
+        when(interesseRepo.findByUsuarioIdWithFetch(99L)).thenReturn(List.of());
+
+        List<InteresseResponse> result = interesseAdocaoService.listarPorUsuario(99L);
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/OrganizacaoServiceTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/OrganizacaoServiceTest.java
@@ -1,0 +1,255 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.OrganizacaoRequestDTO;
+import com.Mybuddy.Myb.DTO.OrganizacaoResponseDTO;
+import com.Mybuddy.Myb.Exception.ConflictException;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.Organizacao;
+import com.Mybuddy.Myb.Repository.OrganizacaoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OrganizacaoServiceTest {
+
+    @Mock
+    private OrganizacaoRepository organizacaoRepository;
+
+    @InjectMocks
+    private OrganizacaoService organizacaoService;
+
+    private Organizacao organizacao;
+    private OrganizacaoRequestDTO requestDTO;
+
+    @BeforeEach
+    void setUp() {
+        organizacao = Organizacao.builder()
+                .id(1L)
+                .nomeFantasia("ONG Patinhas")
+                .emailContato("patinhas@email.com")
+                .cnpj("11.111.111/0001-11")
+                .endereco("Rua A, 123")
+                .telefoneContato("11999990001")
+                .build();
+
+        requestDTO = new OrganizacaoRequestDTO();
+        requestDTO.setNomeFantasia("ONG Patinhas");
+        requestDTO.setEmailContato("patinhas@email.com");
+        requestDTO.setCnpj("11.111.111/0001-11");
+        requestDTO.setEndereco("Rua A, 123");
+        requestDTO.setTelefoneContato("11999990001");
+    }
+
+    // ===================== CRIAR (via entidade) =====================
+
+    @Test
+    void deveCriarOrganizacaoViaEntidadeComSucesso() {
+        when(organizacaoRepository.existsByCnpj(organizacao.getCnpj())).thenReturn(false);
+        when(organizacaoRepository.existsByEmailContato(organizacao.getEmailContato())).thenReturn(false);
+        when(organizacaoRepository.save(any(Organizacao.class))).thenReturn(organizacao);
+
+        Organizacao result = organizacaoService.criarOrganizacao(organizacao);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getNomeFantasia()).isEqualTo("ONG Patinhas");
+        verify(organizacaoRepository, times(1)).save(organizacao);
+    }
+
+    @Test
+    void deveLancarExcecaoAoCriarOrganizacaoViaEntidadeComCnpjDuplicado() {
+        when(organizacaoRepository.existsByCnpj(organizacao.getCnpj())).thenReturn(true);
+
+        assertThatThrownBy(() -> organizacaoService.criarOrganizacao(organizacao))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("CNPJ já cadastrado");
+    }
+
+    @Test
+    void deveLancarExcecaoAoCriarOrganizacaoViaEntidadeComEmailDuplicado() {
+        when(organizacaoRepository.existsByCnpj(organizacao.getCnpj())).thenReturn(false);
+        when(organizacaoRepository.existsByEmailContato(organizacao.getEmailContato())).thenReturn(true);
+
+        assertThatThrownBy(() -> organizacaoService.criarOrganizacao(organizacao))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("E-mail de contato");
+    }
+
+    // ===================== CRIAR (via DTO) =====================
+
+    @Test
+    void deveCriarOrganizacaoViaDTOComSucesso() {
+        when(organizacaoRepository.existsByCnpj(requestDTO.getCnpj())).thenReturn(false);
+        when(organizacaoRepository.existsByEmailContato(requestDTO.getEmailContato())).thenReturn(false);
+        when(organizacaoRepository.save(any(Organizacao.class))).thenReturn(organizacao);
+
+        OrganizacaoResponseDTO result = organizacaoService.criarOrganizacao(requestDTO);
+
+        assertThat(result).isNotNull();
+        verify(organizacaoRepository, times(1)).save(any(Organizacao.class));
+    }
+
+    @Test
+    void deveLancarExcecaoAoCriarOrganizacaoViaDTOComCnpjDuplicado() {
+        when(organizacaoRepository.existsByCnpj(requestDTO.getCnpj())).thenReturn(true);
+
+        assertThatThrownBy(() -> organizacaoService.criarOrganizacao(requestDTO))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("CNPJ já cadastrado");
+    }
+
+    @Test
+    void deveLancarExcecaoAoCriarOrganizacaoViaDTOComEmailDuplicado() {
+        when(organizacaoRepository.existsByCnpj(requestDTO.getCnpj())).thenReturn(false);
+        when(organizacaoRepository.existsByEmailContato(requestDTO.getEmailContato())).thenReturn(true);
+
+        assertThatThrownBy(() -> organizacaoService.criarOrganizacao(requestDTO))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("E-mail de contato");
+    }
+
+    // ===================== BUSCAR =====================
+
+    @Test
+    void deveBuscarOrganizacaoPorIdComSucesso() {
+        when(organizacaoRepository.findById(1L)).thenReturn(Optional.of(organizacao));
+
+        OrganizacaoResponseDTO result = organizacaoService.buscarOrganizacaoPorId(1L);
+
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    void deveLancarExcecaoAoBuscarOrganizacaoPorIdInexistente() {
+        when(organizacaoRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> organizacaoService.buscarOrganizacaoPorId(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Organização não encontrada com ID: 99");
+    }
+
+    @Test
+    void deveBuscarOrganizacaoPorCnpj() {
+        when(organizacaoRepository.findByCnpj("11.111.111/0001-11")).thenReturn(Optional.of(organizacao));
+
+        Optional<Organizacao> result = organizacaoService.buscarOrganizacaoPorCnpj("11.111.111/0001-11");
+
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    void deveRetornarVazioAoBuscarOrganizacaoPorCnpjInexistente() {
+        when(organizacaoRepository.findByCnpj("00.000.000/0000-00")).thenReturn(Optional.empty());
+
+        Optional<Organizacao> result = organizacaoService.buscarOrganizacaoPorCnpj("00.000.000/0000-00");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void deveVerificarExistenciaOrganizacaoPorCnpj() {
+        when(organizacaoRepository.existsByCnpj("11.111.111/0001-11")).thenReturn(true);
+
+        boolean existe = organizacaoService.existeOrganizacaoPorCnpj("11.111.111/0001-11");
+
+        assertThat(existe).isTrue();
+    }
+
+    @Test
+    void deveListarTodasOrganizacoes() {
+        when(organizacaoRepository.findAll()).thenReturn(List.of(organizacao));
+
+        List<OrganizacaoResponseDTO> result = organizacaoService.listarTodasOrganizacoes();
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    void deveRetornarListaVaziaQuandoNaoHouverOrganizacoes() {
+        when(organizacaoRepository.findAll()).thenReturn(List.of());
+
+        List<OrganizacaoResponseDTO> result = organizacaoService.listarTodasOrganizacoes();
+
+        assertThat(result).isEmpty();
+    }
+
+    // ===================== ATUALIZAR =====================
+
+    @Test
+    void deveAtualizarOrganizacaoComSucesso() {
+        when(organizacaoRepository.findById(1L)).thenReturn(Optional.of(organizacao));
+        when(organizacaoRepository.findByCnpj(requestDTO.getCnpj())).thenReturn(Optional.of(organizacao));
+        when(organizacaoRepository.findByEmailContato(requestDTO.getEmailContato())).thenReturn(Optional.of(organizacao));
+        when(organizacaoRepository.save(any(Organizacao.class))).thenReturn(organizacao);
+
+        OrganizacaoResponseDTO result = organizacaoService.atualizarOrganizacao(1L, requestDTO);
+
+        assertThat(result).isNotNull();
+        verify(organizacaoRepository, times(1)).save(any(Organizacao.class));
+    }
+
+    @Test
+    void deveLancarExcecaoAoAtualizarOrganizacaoInexistente() {
+        when(organizacaoRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> organizacaoService.atualizarOrganizacao(99L, requestDTO))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Organização não encontrada para atualização com ID: 99");
+    }
+
+    @Test
+    void deveLancarExcecaoAoAtualizarComCnpjDeOutraOrganizacao() {
+        Organizacao outraOrganizacao = Organizacao.builder().id(2L).build();
+
+        when(organizacaoRepository.findById(1L)).thenReturn(Optional.of(organizacao));
+        when(organizacaoRepository.findByCnpj(requestDTO.getCnpj())).thenReturn(Optional.of(outraOrganizacao));
+
+        assertThatThrownBy(() -> organizacaoService.atualizarOrganizacao(1L, requestDTO))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("CNPJ já cadastrado para outra organização");
+    }
+
+    @Test
+    void deveLancarExcecaoAoAtualizarComEmailDeOutraOrganizacao() {
+        Organizacao outraOrganizacao = Organizacao.builder().id(2L).build();
+
+        when(organizacaoRepository.findById(1L)).thenReturn(Optional.of(organizacao));
+        when(organizacaoRepository.findByCnpj(requestDTO.getCnpj())).thenReturn(Optional.empty());
+        when(organizacaoRepository.findByEmailContato(requestDTO.getEmailContato())).thenReturn(Optional.of(outraOrganizacao));
+
+        assertThatThrownBy(() -> organizacaoService.atualizarOrganizacao(1L, requestDTO))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("E-mail de contato da organização já cadastrado para outra organização");
+    }
+
+    // ===================== DELETAR =====================
+
+    @Test
+    void deveDeletarOrganizacaoComSucesso() {
+        when(organizacaoRepository.existsById(1L)).thenReturn(true);
+
+        organizacaoService.deletarOrganizacao(1L);
+
+        verify(organizacaoRepository, times(1)).deleteById(1L);
+    }
+
+    @Test
+    void deveLancarExcecaoAoDeletarOrganizacaoInexistente() {
+        when(organizacaoRepository.existsById(99L)).thenReturn(false);
+
+        assertThatThrownBy(() -> organizacaoService.deletarOrganizacao(99L))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Organização não encontrada para deleção com ID: 99");
+    }
+}


### PR DESCRIPTION
## Task Jira
- **Card:** [MYB-287](https://mybuddy.atlassian.net/browse/MYB-287)
- **Tipo:** Chore
---
## O que foi feito?
Verificação do relatório JaCoCo e implementação de novos testes unitários para atingir a meta de 60% de cobertura de código. A cobertura evoluiu de 36% para 61%, superando a meta estabelecida.

---
## Escopo das mudanças
- [x] `backend` — Java / Spring Boot
- [ ] `frontend` — Angular
- [ ] `mobile` — Flutter
- [ ] `infra` — Docker / CI / configurações
---
## Checklist de Testes
- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [x] Testes automatizados foram criados ou atualizados (se aplicável)
---
## Checklist de Code Review
- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e são reversíveis
---
## Notas para o Revisor
- Cobertura anterior: **36%** | Cobertura atual: **61%**
- Novos arquivos criados:
  - `OrganizacaoServiceTest.java` — 19 testes cobrindo CRUD completo do OrganizacaoService
  - `InteresseAdocaoServiceTest.java` — 11 testes cobrindo todos os métodos do InteresseAdocaoService
- Evolução por pacote:
  - **Service**: 16% → 61%
  - **Model**: 56% → 90%
  - **DTO**: 0% → 71%
- O `KeycloakIntegrationTest` continua falhando localmente por falta do Docker — esse teste depende de container e não impacta a cobertura
- O relatório foi gerado com o comando: `./mvnw clean test jacoco:report -Dsurefire.excludes=**/KeycloakIntegrationTest.java`
---
## Como testar
```
1. Acessar o módulo Back End
2. Executar: .\mvnw.cmd clean test jacoco:report "-Dsurefire.excludes=**/KeycloakIntegrationTest.java"
3. Abrir target\site\jacoco\index.html no navegador
4. Verificar cobertura total >= 60%
```