### PR TITLE
feat: MY-318: Configurar BLoC como gerenciador de estado com AuthBloc

### DIFF
--- a/mobile/lib/core/errors/failures.dart
+++ b/mobile/lib/core/errors/failures.dart
@@ -1,0 +1,24 @@
+abstract class Failure {
+  final String message;
+  const Failure(this.message);
+}
+
+class ServerFailure extends Failure {
+  const ServerFailure(super.message);
+}
+
+class NetworkFailure extends Failure {
+  const NetworkFailure(super.message);
+}
+
+class AuthFailure extends Failure {
+  const AuthFailure(super.message);
+}
+
+class UnauthorizedFailure extends Failure {
+  const UnauthorizedFailure() : super('Sessão expirada. Faça login novamente.');
+}
+
+class CacheFailure extends Failure {
+  const CacheFailure(super.message);
+}

--- a/mobile/lib/features/auth/domain/entities/user.dart
+++ b/mobile/lib/features/auth/domain/entities/user.dart
@@ -1,0 +1,19 @@
+class User {
+  final String id;
+  final String email;
+  final String nome;
+  final String? telefone;
+  final List<String> roles;
+
+  const User({
+    required this.id,
+    required this.email,
+    required this.nome,
+    this.telefone,
+    required this.roles,
+  });
+
+  bool get isAdmin => roles.contains('ROLE_ADMIN');
+  bool get isOng => roles.contains('ROLE_ONG');
+  bool get isAdotante => roles.contains('ROLE_ADOTANTE');
+}

--- a/mobile/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/mobile/lib/features/auth/domain/repositories/auth_repository.dart
@@ -1,0 +1,10 @@
+import 'package:dartz/dartz.dart';
+import 'package:mybuddy_app/core/errors/failures.dart';
+import 'package:mybuddy_app/features/auth/domain/entities/user.dart';
+
+abstract class AuthRepository {
+  Future<Either<Failure, User>> login(String email, String password);
+  Future<Either<Failure, void>> logout();
+  Future<Either<Failure, User>> getProfile();
+  Future<bool> isAuthenticated();
+}

--- a/mobile/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/mobile/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mybuddy_app/features/auth/domain/repositories/auth_repository.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_event.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+
+class AuthBloc extends Bloc<AuthEvent, AuthState> {
+  final AuthRepository _authRepository;
+
+  AuthBloc({required AuthRepository authRepository})
+      : _authRepository = authRepository,
+        super(AuthInitial()) {
+    on<LoginRequested>(_onLoginRequested);
+    on<LogoutRequested>(_onLogoutRequested);
+    on<CheckAuthStatus>(_onCheckAuthStatus);
+  }
+
+  Future<void> _onLoginRequested(
+    LoginRequested event,
+    Emitter<AuthState> emit,
+  ) async {
+    emit(AuthLoading());
+
+    final result = await _authRepository.login(event.email, event.password);
+
+    result.fold(
+      (failure) => emit(AuthError(failure.message)),
+      (user) => emit(AuthAuthenticated(user)),
+    );
+  }
+
+  Future<void> _onLogoutRequested(
+    LogoutRequested event,
+    Emitter<AuthState> emit,
+  ) async {
+    await _authRepository.logout();
+    emit(AuthUnauthenticated());
+  }
+
+  Future<void> _onCheckAuthStatus(
+    CheckAuthStatus event,
+    Emitter<AuthState> emit,
+  ) async {
+    final isAuthenticated = await _authRepository.isAuthenticated();
+
+    if (isAuthenticated) {
+      final result = await _authRepository.getProfile();
+      result.fold(
+        (failure) => emit(AuthUnauthenticated()),
+        (user) => emit(AuthAuthenticated(user)),
+      );
+    } else {
+      emit(AuthUnauthenticated());
+    }
+  }
+}

--- a/mobile/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/mobile/lib/features/auth/presentation/bloc/auth_event.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+
+abstract class AuthEvent extends Equatable {
+  const AuthEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoginRequested extends AuthEvent {
+  final String email;
+  final String password;
+
+  const LoginRequested({required this.email, required this.password});
+
+  @override
+  List<Object?> get props => [email, password];
+}
+
+class LogoutRequested extends AuthEvent {}
+
+class CheckAuthStatus extends AuthEvent {}

--- a/mobile/lib/features/auth/presentation/bloc/auth_state.dart
+++ b/mobile/lib/features/auth/presentation/bloc/auth_state.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+import 'package:mybuddy_app/features/auth/domain/entities/user.dart';
+
+abstract class AuthState extends Equatable {
+  const AuthState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AuthInitial extends AuthState {}
+
+class AuthLoading extends AuthState {}
+
+class AuthAuthenticated extends AuthState {
+  final User user;
+
+  const AuthAuthenticated(this.user);
+
+  @override
+  List<Object?> get props => [user];
+}
+
+class AuthUnauthenticated extends AuthState {}
+
+class AuthError extends AuthState {
+  final String message;
+
+  const AuthError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-318](https://ederpontes2014.atlassian.net/browse/MY-318)
- **Tipo:** Feature

---

## O que foi feito?

Configuração do `flutter_bloc` como gerenciador de estado da aplicação, com implementação completa do `AuthBloc` cobrindo os fluxos de login, logout e verificação de sessão.

**Arquitetura implementada:**

- `AuthEvent` — eventos: `LoginRequested`, `LogoutRequested`, `CheckAuthStatus`
- `AuthState` — estados: `AuthInitial`, `AuthLoading`, `AuthAuthenticated`, `AuthUnauthenticated`, `AuthError`
- `AuthBloc` — processa eventos e emite estados via `AuthRepository` (abstrato)
- `AuthRepository` — contrato do domínio com `login()`, `logout()`, `getProfile()`, `isAuthenticated()`
- `User` — entidade de domínio com `id`, `email`, `nome`, `telefone`, `roles` e getters de role (`isAdmin`, `isOng`, `isAdotante`)
- `Failure` — hierarquia de erros: `ServerFailure`, `NetworkFailure`, `AuthFailure`, `UnauthorizedFailure`, `CacheFailure`

**Padrão seguido:** Clean Arch — BLoC na camada de apresentação, repositório abstrato no domínio, implementação concreta na camada de dados (pendente MY-322/MY-323).

---

## Arquivos criados

- `features/auth/domain/entities/user.dart`
- `features/auth/domain/repositories/auth_repository.dart`
- `features/auth/presentation/bloc/auth_bloc.dart`
- `features/auth/presentation/bloc/auth_event.dart`
- `features/auth/presentation/bloc/auth_state.dart`
- `core/errors/failures.dart`

---

## Escopo das mudanças

- [x] `mobile` — Flutter

---

## Checklist de Testes

- [x] `flutter build web` compila sem erros
- [ ] Testes unitários do AuthBloc — pendente MY-312
- [ ] Integração com implementação real do repositório — pendente MY-322/MY-323

---

## Notas para o Revisor

- O `AuthRepository` é abstrato — a implementação real com Keycloak/OAuth2 será feita na MY-322/MY-323
- Os warnings de WASM do `flutter_secure_storage_web` são esperados e não afetam o build padrão
- O `AuthBloc` usa `dartz` Either para tratamento de erros seguindo o padrão funcional do projeto

[MY-318]: https://ederpontes2014.atlassian.net/browse/MY-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ