### PR TITLE
My 319 configurar roteamento gorouter

### DIFF
--- a/mobile/ios/Flutter/Debug.xcconfig
+++ b/mobile/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/mobile/ios/Flutter/Release.xcconfig
+++ b/mobile/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/mobile/ios/Podfile
+++ b/mobile/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -1,17 +1,42 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mybuddy_app/core/di/injection_container.dart' as di;
 import 'package:mybuddy_app/core/router/app_router.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_event.dart';
 import 'package:mybuddy_app/shared/theme/app_theme.dart';
 
-class MyBuddyApp extends StatelessWidget {
+class MyBuddyApp extends StatefulWidget {
   const MyBuddyApp({super.key});
 
   @override
+  State<MyBuddyApp> createState() => _MyBuddyAppState();
+}
+
+class _MyBuddyAppState extends State<MyBuddyApp> {
+  late final AuthBloc _authBloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _authBloc = di.sl<AuthBloc>();
+    _authBloc.add(CheckAuthStatus());
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(
-      title: 'MyBuddy',
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.light,
-      routerConfig: AppRouter.router,
+    return BlocProvider.value(
+      value: _authBloc,
+      child: Builder(
+        builder: (context) {
+          return MaterialApp.router(
+            title: 'MyBuddy',
+            debugShowCheckedModeBanner: false,
+            theme: AppTheme.light,
+            routerConfig: AppRouter.router(context),
+          );
+        },
+      ),
     );
   }
 }

--- a/mobile/lib/core/di/injection_container.dart
+++ b/mobile/lib/core/di/injection_container.dart
@@ -1,11 +1,14 @@
 import 'package:get_it/get_it.dart';
+import 'package:mybuddy_app/features/auth/data/repositories/auth_repository_mock.dart';
+import 'package:mybuddy_app/features/auth/domain/repositories/auth_repository.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
 
 final sl = GetIt.instance;
 
 Future<void> init() async {
-  // Auth
-  // sl.registerFactory(() => AuthBloc(loginUsecase: sl()));
+  // BLoC
+  sl.registerFactory(() => AuthBloc(authRepository: sl()));
 
-  // Core
-  // sl.registerLazySingleton(() => DioClient());
+  // Repository
+  sl.registerLazySingleton<AuthRepository>(() => AuthRepositoryMock());
 }

--- a/mobile/lib/core/router/app_router.dart
+++ b/mobile/lib/core/router/app_router.dart
@@ -1,14 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
 import 'package:mybuddy_app/features/auth/presentation/pages/login_page.dart';
+import 'package:mybuddy_app/features/pets/presentation/pages/pets_page.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/pages/marketplace_page.dart';
+import 'package:mybuddy_app/features/adocao/presentation/pages/adocao_page.dart';
+import 'package:mybuddy_app/shared/widgets/main_scaffold.dart';
 
 class AppRouter {
-  static final router = GoRouter(
-    initialLocation: '/login',
-    routes: [
-      GoRoute(
-        path: '/login',
-        builder: (context, state) => const LoginPage(),
+  static GoRouter router(BuildContext context) {
+    return GoRouter(
+      initialLocation: '/login',
+      redirect: (context, state) {
+        final authState = context.read<AuthBloc>().state;
+        final isAuthenticated = authState is AuthAuthenticated;
+        final isLoggingIn = state.matchedLocation == '/login';
+
+        if (!isAuthenticated && !isLoggingIn) return '/login';
+        if (isAuthenticated && isLoggingIn) return '/pets';
+        return null;
+      },
+      routes: [
+        GoRoute(
+          path: '/login',
+          name: 'login',
+          builder: (context, state) => const LoginPage(),
+        ),
+        ShellRoute(
+          builder: (context, state, child) => MainScaffold(child: child),
+          routes: [
+            GoRoute(
+              path: '/pets',
+              name: 'pets',
+              builder: (context, state) => const PetsPage(),
+            ),
+            GoRoute(
+              path: '/marketplace',
+              name: 'marketplace',
+              builder: (context, state) => const MarketplacePage(),
+            ),
+            GoRoute(
+              path: '/adocao',
+              name: 'adocao',
+              builder: (context, state) => const AdocaoPage(),
+            ),
+          ],
+        ),
+      ],
+      errorBuilder: (context, state) => Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Icon(Icons.error_outline, size: 64, color: Colors.red),
+              const SizedBox(height: 16),
+              Text(
+                'Página não encontrada',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: () => context.go('/pets'),
+                child: const Text('Voltar ao início'),
+              ),
+            ],
+          ),
+        ),
       ),
-    ],
-  );
+    );
+  }
 }

--- a/mobile/lib/features/adocao/presentation/pages/adocao_page.dart
+++ b/mobile/lib/features/adocao/presentation/pages/adocao_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class AdocaoPage extends StatelessWidget {
+  const AdocaoPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Adoção'),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/auth/data/repositories/auth_repository_mock.dart
+++ b/mobile/lib/features/auth/data/repositories/auth_repository_mock.dart
@@ -1,0 +1,43 @@
+import 'package:dartz/dartz.dart';
+import 'package:mybuddy_app/core/errors/failures.dart';
+import 'package:mybuddy_app/features/auth/domain/entities/user.dart';
+import 'package:mybuddy_app/features/auth/domain/repositories/auth_repository.dart';
+
+class AuthRepositoryMock implements AuthRepository {
+  bool _isAuthenticated = false;
+  User? _currentUser;
+
+  @override
+  Future<Either<Failure, User>> login(String email, String password) async {
+    await Future.delayed(const Duration(seconds: 1));
+
+    if (email == 'adotante@mybuddy.com' && password == 'T1234567') {
+      _currentUser = const User(
+        id: '5df8a715-5321-4dc7-b388-5325ce4253d1',
+        email: 'adotante@mybuddy.com',
+        nome: 'Adotante MyBuddy',
+        roles: ['ROLE_ADOTANTE'],
+      );
+      _isAuthenticated = true;
+      return Right(_currentUser!);
+    }
+
+    return const Left(AuthFailure('Email ou senha inválidos'));
+  }
+
+  @override
+  Future<Either<Failure, void>> logout() async {
+    _isAuthenticated = false;
+    _currentUser = null;
+    return const Right(null);
+  }
+
+  @override
+  Future<Either<Failure, User>> getProfile() async {
+    if (_currentUser != null) return Right(_currentUser!);
+    return const Left(AuthFailure('Usuário não autenticado'));
+  }
+
+  @override
+  Future<bool> isAuthenticated() async => _isAuthenticated;
+}

--- a/mobile/lib/features/auth/presentation/pages/login_page.dart
+++ b/mobile/lib/features/auth/presentation/pages/login_page.dart
@@ -1,35 +1,148 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_event.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
 
-class LoginPage extends StatelessWidget {
+class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
 
   @override
+  State<LoginPage> createState() => _LoginPageState();
+}
+
+class _LoginPageState extends State<LoginPage> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _onLogin() {
+    if (_formKey.currentState?.validate() ?? false) {
+      context.read<AuthBloc>().add(LoginRequested(
+            email: _emailController.text.trim(),
+            password: _passwordController.text,
+          ));
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.pets,
-              size: 80,
-              color: Theme.of(context).colorScheme.primary,
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is AuthAuthenticated) {
+          context.go('/pets');
+        } else if (state is AuthError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(state.message),
+              backgroundColor: Colors.red,
             ),
-            const SizedBox(height: 24),
-            Text(
-              'MyBuddy',
-              style: Theme.of(context).textTheme.headlineLarge?.copyWith(
-                    fontWeight: FontWeight.bold,
+          );
+        }
+      },
+      child: Scaffold(
+        body: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  const SizedBox(height: 48),
+                  Icon(
+                    Icons.pets,
+                    size: 80,
+                    color: Theme.of(context).colorScheme.primary,
                   ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Conectando pets a lares',
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: Colors.grey,
+                  const SizedBox(height: 16),
+                  Text(
+                    'MyBuddy',
+                    style: Theme.of(context).textTheme.headlineLarge?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Conectando pets a lares',
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          color: Colors.grey,
+                        ),
+                  ),
+                  const SizedBox(height: 48),
+                  TextFormField(
+                    controller: _emailController,
+                    keyboardType: TextInputType.emailAddress,
+                    decoration: const InputDecoration(
+                      labelText: 'Email',
+                      prefixIcon: Icon(Icons.email_outlined),
+                    ),
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Informe o email';
+                      }
+                      if (!value.contains('@')) {
+                        return 'Email inválido';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _passwordController,
+                    obscureText: _obscurePassword,
+                    decoration: InputDecoration(
+                      labelText: 'Senha',
+                      prefixIcon: const Icon(Icons.lock_outlined),
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscurePassword
+                              ? Icons.visibility_outlined
+                              : Icons.visibility_off_outlined,
+                        ),
+                        onPressed: () => setState(
+                            () => _obscurePassword = !_obscurePassword),
+                      ),
+                    ),
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Informe a senha';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 32),
+                  BlocBuilder<AuthBloc, AuthState>(
+                    builder: (context, state) {
+                      return ElevatedButton(
+                        onPressed:
+                            state is AuthLoading ? null : _onLogin,
+                        child: state is AuthLoading
+                            ? const SizedBox(
+                                height: 20,
+                                width: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              )
+                            : const Text('Entrar'),
+                      );
+                    },
+                  ),
+                ],
+              ),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/mobile/lib/features/marketplace/presentation/pages/marketplace_page.dart
+++ b/mobile/lib/features/marketplace/presentation/pages/marketplace_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class MarketplacePage extends StatelessWidget {
+  const MarketplacePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Marketplace'),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/pets/presentation/pages/pets_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/pets_page.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+
+class PetsPage extends StatelessWidget {
+  const PetsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('Pets'),
+      ),
+    );
+  }
+}

--- a/mobile/lib/shared/widgets/main_scaffold.dart
+++ b/mobile/lib/shared/widgets/main_scaffold.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class MainScaffold extends StatelessWidget {
+  final Widget child;
+
+  const MainScaffold({super.key, required this.child});
+
+  int _currentIndex(BuildContext context) {
+    final location = GoRouterState.of(context).matchedLocation;
+    if (location.startsWith('/marketplace')) return 1;
+    if (location.startsWith('/adocao')) return 2;
+    return 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: child,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _currentIndex(context),
+        selectedItemColor: Theme.of(context).colorScheme.primary,
+        unselectedItemColor: Colors.grey,
+        onTap: (index) {
+          switch (index) {
+            case 0:
+              context.go('/pets');
+            case 1:
+              context.go('/marketplace');
+            case 2:
+              context.go('/adocao');
+          }
+        },
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.pets),
+            label: 'Pets',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.store),
+            label: 'Marketplace',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.favorite),
+            label: 'Adoção',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/macos/Flutter/Flutter-Debug.xcconfig
+++ b/mobile/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/mobile/macos/Flutter/Flutter-Release.xcconfig
+++ b/mobile/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/mobile/macos/Podfile
+++ b/mobile/macos/Podfile
@@ -1,0 +1,42 @@
+platform :osx, '10.15'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-319](https://ederpontes2014.atlassian.net/browse/MY-319)
- **Tipo:** Feature

---

## O que foi feito?

Configuração completa do roteamento com GoRouter, incluindo guard de autenticação, ShellRoute com bottom navigation e tela de login funcional integrada ao AuthBloc.

**Fluxo implementado:**
1. App inicia → `CheckAuthStatus` disparado no `AuthBloc`
2. Não autenticado → redirect automático para `/login`
3. Login com sucesso → redirect para `/pets`
4. Autenticado tentando acessar `/login` → redirect para `/pets`
5. Rota não encontrada → página de erro com botão de retorno

**Rotas configuradas:**
- `/login` — tela de login
- `/pets` — listagem de pets (ShellRoute)
- `/marketplace` — marketplace (ShellRoute)
- `/adocao` — adoção (ShellRoute)

**ShellRoute** com `MainScaffold` — bottom navigation bar persistente entre rotas autenticadas.

---

## Arquivos criados/modificados

- `core/router/app_router.dart` — GoRouter com redirect guard e ShellRoute
- `lib/app.dart` — BlocProvider do AuthBloc + router com context
- `features/auth/presentation/pages/login_page.dart` — tela de login completa com validação e BlocListener
- `features/auth/data/repositories/auth_repository_mock.dart` — implementação mock do AuthRepository para desenvolvimento
- `core/di/injection_container.dart` — registro do AuthBloc e AuthRepositoryMock no GetIt
- `features/pets/presentation/pages/pets_page.dart` — placeholder
- `features/marketplace/presentation/pages/marketplace_page.dart` — placeholder
- `features/adocao/presentation/pages/adocao_page.dart` — placeholder
- `shared/widgets/main_scaffold.dart` — scaffold com BottomNavigationBar

---

## Escopo das mudanças

- [x] `mobile` — Flutter

---

## Checklist de Testes

- [x] App roda no Chrome sem erros
- [x] Redirect para `/login` quando não autenticado
- [x] Login com mock (`adotante@mybuddy.com` / `T1234567`) funciona
- [x] Redirect para `/pets` após login
- [x] BottomNav navega corretamente entre `/pets`, `/marketplace` e `/adocao`
- [x] Erro de credenciais exibe snackbar vermelho
- [ ] Integração com Keycloak real — pendente MY-322/MY-323

---

## Notas para o Revisor

- O `AuthRepositoryMock` é temporário — será substituído pela implementação real com Keycloak na MY-322/MY-323
- O router recebe `BuildContext` pra conseguir acessar o `AuthBloc` via `context.read()` no redirect guard
- **Atenção:** quando a implementação real do Keycloak for feita, o mock deve ser removido do `injection_container.dart`

[MY-319]: https://ederpontes2014.atlassian.net/browse/MY-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ