### PR TITLE
My 327 tela login com o auth2 keycloak

### DIFF
--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -33,6 +33,8 @@ class _MyBuddyAppState extends State<MyBuddyApp> {
             title: 'MyBuddy',
             debugShowCheckedModeBanner: false,
             theme: AppTheme.light,
+            darkTheme: AppTheme.dark,
+            themeMode: ThemeMode.system,
             routerConfig: AppRouter.router(context),
           );
         },

--- a/mobile/lib/core/di/injection_container.dart
+++ b/mobile/lib/core/di/injection_container.dart
@@ -4,12 +4,14 @@ import 'package:mybuddy_app/core/network/dio_client.dart';
 import 'package:mybuddy_app/features/auth/data/repositories/auth_repository_mock.dart';
 import 'package:mybuddy_app/features/auth/domain/repositories/auth_repository.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/favoritos_cubit.dart';
 
 final sl = GetIt.instance;
 
 Future<void> init() async {
   _registerCore();
   _registerAuth();
+  _registerPets();
 }
 
 void _registerCore() {
@@ -28,3 +30,11 @@ void _registerAuth() {
     () => AuthRepositoryMock(),
   );
 }
+
+void _registerPets() {
+  // Cubit de favoritos persistente na sessão
+  sl.registerLazySingleton<FavoritosCubit>(
+    () => FavoritosCubit(),
+  );
+}
+

--- a/mobile/lib/core/router/app_router.dart
+++ b/mobile/lib/core/router/app_router.dart
@@ -7,6 +7,8 @@ import 'package:mybuddy_app/features/auth/presentation/pages/login_page.dart';
 import 'package:mybuddy_app/features/auth/presentation/pages/splash_page.dart';
 import 'package:mybuddy_app/features/auth/presentation/pages/onboarding_page.dart';
 import 'package:mybuddy_app/features/pets/presentation/pages/pets_page.dart';
+import 'package:mybuddy_app/features/pets/presentation/pages/favoritos_page.dart';
+import 'package:mybuddy_app/features/pets/presentation/pages/perfil_page.dart';
 import 'package:mybuddy_app/features/marketplace/presentation/pages/marketplace_page.dart';
 import 'package:mybuddy_app/features/adocao/presentation/pages/adocao_page.dart';
 import 'package:mybuddy_app/shared/widgets/main_scaffold.dart';
@@ -62,6 +64,11 @@ class AppRouter {
               builder: (context, state) => const PetsPage(),
             ),
             GoRoute(
+              path: '/favoritos',
+              name: 'favoritos',
+              builder: (context, state) => const FavoritosPage(),
+            ),
+            GoRoute(
               path: '/marketplace',
               name: 'marketplace',
               builder: (context, state) => const MarketplacePage(),
@@ -70,6 +77,11 @@ class AppRouter {
               path: '/adocao',
               name: 'adocao',
               builder: (context, state) => const AdocaoPage(),
+            ),
+            GoRoute(
+              path: '/perfil',
+              name: 'perfil',
+              builder: (context, state) => const PerfilPage(),
             ),
           ],
         ),

--- a/mobile/lib/core/router/app_router.dart
+++ b/mobile/lib/core/router/app_router.dart
@@ -14,6 +14,32 @@ import 'package:mybuddy_app/features/adocao/presentation/pages/adocao_page.dart'
 import 'package:mybuddy_app/shared/widgets/main_scaffold.dart';
 
 class AppRouter {
+  static CustomTransitionPage<void> _fadeRoute(GoRouterState state, Widget child) {
+    return CustomTransitionPage<void>(
+      key: state.pageKey,
+      child: child,
+      transitionDuration: const Duration(milliseconds: 250),
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        return FadeTransition(opacity: animation, child: child);
+      },
+    );
+  }
+
+  static CustomTransitionPage<void> _slideRoute(GoRouterState state, Widget child) {
+    return CustomTransitionPage<void>(
+      key: state.pageKey,
+      child: child,
+      transitionDuration: const Duration(milliseconds: 350),
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        const begin = Offset(1.0, 0.0);
+        const end = Offset.zero;
+        const curve = Curves.easeInOutCubic;
+        final tween = Tween(begin: begin, end: end).chain(CurveTween(curve: curve));
+        return SlideTransition(position: animation.drive(tween), child: child);
+      },
+    );
+  }
+
   static GoRouter router(BuildContext context) {
     return GoRouter(
       initialLocation: '/splash',
@@ -43,17 +69,17 @@ class AppRouter {
         GoRoute(
           path: '/splash',
           name: 'splash',
-          builder: (context, state) => const SplashPage(),
+          pageBuilder: (context, state) => _fadeRoute(state, const SplashPage()),
         ),
         GoRoute(
           path: '/onboarding',
           name: 'onboarding',
-          builder: (context, state) => const OnboardingPage(),
+          pageBuilder: (context, state) => _slideRoute(state, const OnboardingPage()),
         ),
         GoRoute(
           path: '/login',
           name: 'login',
-          builder: (context, state) => const LoginPage(),
+          pageBuilder: (context, state) => _slideRoute(state, const LoginPage()),
         ),
         ShellRoute(
           builder: (context, state, child) => MainScaffold(child: child),
@@ -61,27 +87,27 @@ class AppRouter {
             GoRoute(
               path: '/pets',
               name: 'pets',
-              builder: (context, state) => const PetsPage(),
+              pageBuilder: (context, state) => _fadeRoute(state, const PetsPage()),
             ),
             GoRoute(
               path: '/favoritos',
               name: 'favoritos',
-              builder: (context, state) => const FavoritosPage(),
+              pageBuilder: (context, state) => _fadeRoute(state, const FavoritosPage()),
             ),
             GoRoute(
               path: '/marketplace',
               name: 'marketplace',
-              builder: (context, state) => const MarketplacePage(),
+              pageBuilder: (context, state) => _fadeRoute(state, const MarketplacePage()),
             ),
             GoRoute(
               path: '/adocao',
               name: 'adocao',
-              builder: (context, state) => const AdocaoPage(),
+              pageBuilder: (context, state) => _fadeRoute(state, const AdocaoPage()),
             ),
             GoRoute(
               path: '/perfil',
               name: 'perfil',
-              builder: (context, state) => const PerfilPage(),
+              pageBuilder: (context, state) => _fadeRoute(state, const PerfilPage()),
             ),
           ],
         ),

--- a/mobile/lib/core/router/app_router.dart
+++ b/mobile/lib/core/router/app_router.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
 import 'package:mybuddy_app/features/auth/presentation/pages/login_page.dart';
+import 'package:mybuddy_app/features/auth/presentation/pages/splash_page.dart';
+import 'package:mybuddy_app/features/auth/presentation/pages/onboarding_page.dart';
 import 'package:mybuddy_app/features/pets/presentation/pages/pets_page.dart';
 import 'package:mybuddy_app/features/marketplace/presentation/pages/marketplace_page.dart';
 import 'package:mybuddy_app/features/adocao/presentation/pages/adocao_page.dart';
@@ -12,17 +14,40 @@ import 'package:mybuddy_app/shared/widgets/main_scaffold.dart';
 class AppRouter {
   static GoRouter router(BuildContext context) {
     return GoRouter(
-      initialLocation: '/login',
+      initialLocation: '/splash',
       redirect: (context, state) {
         final authState = context.read<AuthBloc>().state;
         final isAuthenticated = authState is AuthAuthenticated;
-        final isLoggingIn = state.matchedLocation == '/login';
+        final location = state.matchedLocation;
 
-        if (!isAuthenticated && !isLoggingIn) return '/login';
-        if (isAuthenticated && isLoggingIn) return '/pets';
+        final isSplash = location == '/splash';
+        final isOnboarding = location == '/onboarding';
+        final isLogin = location == '/login';
+
+        if (!isAuthenticated) {
+          // Se não estiver logado, permite acessar apenas splash, onboarding e login
+          if (isSplash || isOnboarding || isLogin) return null;
+          return '/splash';
+        }
+
+        // Se estiver autenticado e tentar ir para as telas de auth, manda para o feed
+        if (isAuthenticated && (isSplash || isOnboarding || isLogin)) {
+          return '/pets';
+        }
+
         return null;
       },
       routes: [
+        GoRoute(
+          path: '/splash',
+          name: 'splash',
+          builder: (context, state) => const SplashPage(),
+        ),
+        GoRoute(
+          path: '/onboarding',
+          name: 'onboarding',
+          builder: (context, state) => const OnboardingPage(),
+        ),
         GoRoute(
           path: '/login',
           name: 'login',

--- a/mobile/lib/features/auth/data/repositories/auth_repository_mock.dart
+++ b/mobile/lib/features/auth/data/repositories/auth_repository_mock.dart
@@ -26,6 +26,19 @@ class AuthRepositoryMock implements AuthRepository {
   }
 
   @override
+  Future<Either<Failure, User>> loginWithKeycloak() async {
+    await Future.delayed(const Duration(milliseconds: 1500));
+    _currentUser = const User(
+      id: '5df8a715-5321-4dc7-b388-5325ce4253e2',
+      email: 'keycloak@mybuddy.com',
+      nome: 'Eder Henrique (SSO)',
+      roles: ['ROLE_ADOTANTE'],
+    );
+    _isAuthenticated = true;
+    return Right(_currentUser!);
+  }
+
+  @override
   Future<Either<Failure, void>> logout() async {
     _isAuthenticated = false;
     _currentUser = null;

--- a/mobile/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/mobile/lib/features/auth/domain/repositories/auth_repository.dart
@@ -4,6 +4,7 @@ import 'package:mybuddy_app/features/auth/domain/entities/user.dart';
 
 abstract class AuthRepository {
   Future<Either<Failure, User>> login(String email, String password);
+  Future<Either<Failure, User>> loginWithKeycloak();
   Future<Either<Failure, void>> logout();
   Future<Either<Failure, User>> getProfile();
   Future<bool> isAuthenticated();

--- a/mobile/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/mobile/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -10,6 +10,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       : _authRepository = authRepository,
         super(AuthInitial()) {
     on<LoginRequested>(_onLoginRequested);
+    on<LoginWithKeycloakRequested>(_onLoginWithKeycloakRequested);
     on<LogoutRequested>(_onLogoutRequested);
     on<CheckAuthStatus>(_onCheckAuthStatus);
   }
@@ -21,6 +22,20 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     emit(AuthLoading());
 
     final result = await _authRepository.login(event.email, event.password);
+
+    result.fold(
+      (failure) => emit(AuthError(failure.message)),
+      (user) => emit(AuthAuthenticated(user)),
+    );
+  }
+
+  Future<void> _onLoginWithKeycloakRequested(
+    LoginWithKeycloakRequested event,
+    Emitter<AuthState> emit,
+  ) async {
+    emit(AuthLoading());
+
+    final result = await _authRepository.loginWithKeycloak();
 
     result.fold(
       (failure) => emit(AuthError(failure.message)),

--- a/mobile/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/mobile/lib/features/auth/presentation/bloc/auth_event.dart
@@ -20,3 +20,5 @@ class LoginRequested extends AuthEvent {
 class LogoutRequested extends AuthEvent {}
 
 class CheckAuthStatus extends AuthEvent {}
+
+class LoginWithKeycloakRequested extends AuthEvent {}

--- a/mobile/lib/features/auth/presentation/pages/login_page.dart
+++ b/mobile/lib/features/auth/presentation/pages/login_page.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_event.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+import 'package:mybuddy_app/shared/widgets/app_button.dart';
+import 'package:mybuddy_app/shared/widgets/app_input.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -16,7 +18,6 @@ class _LoginPageState extends State<LoginPage> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   final _formKey = GlobalKey<FormState>();
-  bool _obscurePassword = true;
 
   @override
   void dispose() {
@@ -79,13 +80,12 @@ class _LoginPageState extends State<LoginPage> {
                         ),
                   ),
                   const SizedBox(height: 48),
-                  TextFormField(
+                  AppInput(
                     controller: _emailController,
+                    labelText: 'Email',
+                    hintText: 'Digite seu email',
                     keyboardType: TextInputType.emailAddress,
-                    decoration: const InputDecoration(
-                      labelText: 'Email',
-                      prefixIcon: Icon(Icons.email_outlined),
-                    ),
+                    prefixIcon: Icons.email_outlined,
                     validator: (value) {
                       if (value == null || value.isEmpty) {
                         return 'Informe o email';
@@ -97,22 +97,14 @@ class _LoginPageState extends State<LoginPage> {
                     },
                   ),
                   const SizedBox(height: 16),
-                  TextFormField(
+                  AppInput(
                     controller: _passwordController,
-                    obscureText: _obscurePassword,
-                    decoration: InputDecoration(
-                      labelText: 'Senha',
-                      prefixIcon: const Icon(Icons.lock_outlined),
-                      suffixIcon: IconButton(
-                        icon: Icon(
-                          _obscurePassword
-                              ? Icons.visibility_outlined
-                              : Icons.visibility_off_outlined,
-                        ),
-                        onPressed: () => setState(
-                            () => _obscurePassword = !_obscurePassword),
-                      ),
-                    ),
+                    labelText: 'Senha',
+                    hintText: 'Digite sua senha',
+                    isPassword: true,
+                    prefixIcon: Icons.lock_outlined,
+                    textInputAction: TextInputAction.done,
+                    onFieldSubmitted: (_) => _onLogin(),
                     validator: (value) {
                       if (value == null || value.isEmpty) {
                         return 'Informe a senha';
@@ -123,19 +115,10 @@ class _LoginPageState extends State<LoginPage> {
                   const SizedBox(height: 32),
                   BlocBuilder<AuthBloc, AuthState>(
                     builder: (context, state) {
-                      return ElevatedButton(
-                        onPressed:
-                            state is AuthLoading ? null : _onLogin,
-                        child: state is AuthLoading
-                            ? const SizedBox(
-                                height: 20,
-                                width: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  color: Colors.white,
-                                ),
-                              )
-                            : const Text('Entrar'),
+                      return AppButton(
+                        text: 'Entrar',
+                        isLoading: state is AuthLoading,
+                        onPressed: _onLogin,
                       );
                     },
                   ),

--- a/mobile/lib/features/auth/presentation/pages/login_page.dart
+++ b/mobile/lib/features/auth/presentation/pages/login_page.dart
@@ -6,6 +6,7 @@ import 'package:mybuddy_app/features/auth/presentation/bloc/auth_event.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
 import 'package:mybuddy_app/shared/widgets/app_button.dart';
 import 'package:mybuddy_app/shared/widgets/app_input.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -115,10 +116,63 @@ class _LoginPageState extends State<LoginPage> {
                   const SizedBox(height: 32),
                   BlocBuilder<AuthBloc, AuthState>(
                     builder: (context, state) {
-                      return AppButton(
-                        text: 'Entrar',
-                        isLoading: state is AuthLoading,
-                        onPressed: _onLogin,
+                      final isDark = Theme.of(context).brightness == Brightness.dark;
+                      return Column(
+                        children: [
+                          AppButton(
+                            text: 'Entrar',
+                            isLoading: state is AuthLoading,
+                            onPressed: _onLogin,
+                          ),
+                          const SizedBox(height: 24),
+                          Row(
+                            children: [
+                              Expanded(child: Divider(color: isDark ? AppColors.darkBorder : AppColors.border)),
+                              Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 16),
+                                child: Text(
+                                  'ou continue com',
+                                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                        color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                      ),
+                                ),
+                              ),
+                              Expanded(child: Divider(color: isDark ? AppColors.darkBorder : AppColors.border)),
+                            ],
+                          ),
+                          const SizedBox(height: 24),
+                          AppButton(
+                            text: 'Entrar com Keycloak',
+                            type: AppButtonType.outline,
+                            isLoading: state is AuthLoading,
+                            icon: Icons.vpn_key_outlined,
+                            onPressed: () {
+                              context.read<AuthBloc>().add(LoginWithKeycloakRequested());
+                            },
+                          ),
+                          const SizedBox(height: 32),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                'Não tem uma conta? ',
+                                style: TextStyle(
+                                  color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                ),
+                              ),
+                              GestureDetector(
+                                onTap: () => context.go('/cadastro'),
+                                child: const Text(
+                                  'Cadastre-se',
+                                  style: TextStyle(
+                                    color: AppColors.primary,
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
                       );
                     },
                   ),

--- a/mobile/lib/features/auth/presentation/pages/onboarding_page.dart
+++ b/mobile/lib/features/auth/presentation/pages/onboarding_page.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:mybuddy_app/shared/widgets/app_button.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+
+class OnboardingPage extends StatefulWidget {
+  const OnboardingPage({super.key});
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  final List<OnboardingSlide> _slides = [
+    const OnboardingSlide(
+      title: 'Encontre o seu parceiro perfeito',
+      description: 'Milhares de cães e gatos estão esperando por um lar amoroso. Filtre por tamanho, idade e temperamento para achar o ideal.',
+      icon: Icons.favorite_rounded,
+    ),
+    const OnboardingSlide(
+      title: 'Tudo para o seu melhor amigo',
+      description: 'Explore nosso marketplace com rações, brinquedos e serviços qualificados de petshops parceiros diretamente no seu celular.',
+      icon: Icons.shopping_bag_rounded,
+    ),
+    const OnboardingSlide(
+      title: 'Apoie a causa animal',
+      description: 'Doe valores diretamente para ONGs de forma transparente ou ajude a manter campanhas de resgate e saúde de pets.',
+      icon: Icons.volunteer_activism_rounded,
+    ),
+  ];
+
+  Future<void> _completeOnboarding() async {
+    const storage = FlutterSecureStorage();
+    await storage.write(key: 'onboarding_seen', value: 'true');
+    if (mounted) {
+      context.go('/login');
+    }
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            // Botão Pular (Skip)
+            Align(
+              alignment: Alignment.topRight,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                child: TextButton(
+                  onPressed: _completeOnboarding,
+                  child: Text(
+                    'Pular',
+                    style: TextStyle(
+                      color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+
+            // PageView dos slides
+            Expanded(
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: _slides.length,
+                onPageChanged: (index) {
+                  setState(() {
+                    _currentPage = index;
+                  });
+                },
+                itemBuilder: (context, index) {
+                  return _slides[index];
+                },
+              ),
+            ),
+
+            // Indicador de Páginas e Botão Continuar
+            Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                children: [
+                  // Dots indicador
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: List.generate(
+                      _slides.length,
+                      (index) => AnimatedContainer(
+                        duration: const Duration(milliseconds: 300),
+                        margin: const EdgeInsets.symmetric(horizontal: 4.0),
+                        height: 8.0,
+                        width: _currentPage == index ? 24.0 : 8.0,
+                        decoration: BoxDecoration(
+                          color: _currentPage == index
+                              ? AppColors.primary
+                              : (isDark ? AppColors.darkBorder : Colors.grey.shade300),
+                          borderRadius: BorderRadius.circular(4.0),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+
+                  // Botão Avançar / Começar
+                  AppButton(
+                    text: _currentPage == _slides.length - 1 ? 'Começar' : 'Próximo',
+                    onPressed: () {
+                      if (_currentPage < _slides.length - 1) {
+                        _pageController.nextPage(
+                          duration: const Duration(milliseconds: 300),
+                          curve: Curves.easeIn,
+                        );
+                      } else {
+                        _completeOnboarding();
+                      }
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class OnboardingSlide extends StatelessWidget {
+  final String title;
+  final String description;
+  final IconData icon;
+
+  const OnboardingSlide({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32.0),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          // Ícone central decorado
+          Container(
+            height: 180,
+            width: 180,
+            decoration: BoxDecoration(
+              color: AppColors.primary.withAlpha(15),
+              shape: BoxShape.circle,
+            ),
+            child: Center(
+              child: Icon(
+                icon,
+                size: 80,
+                color: AppColors.primary,
+              ),
+            ),
+          ),
+          const SizedBox(height: 48),
+
+          // Título
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: isDark ? Colors.white : Colors.black87,
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // Descrição
+          Text(
+            description,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+              height: 1.5,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/auth/presentation/pages/splash_page.dart
+++ b/mobile/lib/features/auth/presentation/pages/splash_page.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+
+class SplashPage extends StatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends State<SplashPage> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _fadeAnimation;
+  late Animation<double> _scaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    );
+
+    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeIn),
+    );
+
+    _scaleAnimation = Tween<double>(begin: 0.8, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.elasticOut),
+    );
+
+    _controller.forward();
+    _navigateToNextScreen();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _navigateToNextScreen() async {
+    // Aguarda o tempo da animação (1.8 segundos)
+    await Future.delayed(const Duration(milliseconds: 2000));
+    if (!mounted) return;
+
+    final authState = context.read<AuthBloc>().state;
+    
+    if (authState is AuthAuthenticated) {
+      context.go('/pets');
+    } else {
+      const storage = FlutterSecureStorage();
+      final seenOnboarding = await storage.read(key: 'onboarding_seen') == 'true';
+      if (!mounted) return;
+      
+      if (seenOnboarding) {
+        context.go('/login');
+      } else {
+        context.go('/onboarding');
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      body: Center(
+        child: FadeTransition(
+          opacity: _fadeAnimation,
+          child: ScaleTransition(
+            scale: _scaleAnimation,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(24),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary.withAlpha(20),
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    Icons.pets,
+                    size: 100,
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Text(
+                  'MyBuddy',
+                  style: theme.textTheme.displaySmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: isDark ? Colors.white : Colors.black87,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Conectando pets a lares',
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    color: Colors.grey,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/pets/domain/entities/pet.dart
+++ b/mobile/lib/features/pets/domain/entities/pet.dart
@@ -1,0 +1,29 @@
+class Pet {
+  final String id;
+  final String nome;
+  final String especie;
+  final String raca;
+  final int idade;
+  final String sexo;
+  final String porte;
+  final String cidade;
+  final String estado;
+  final String imagemUrl;
+  final bool vacinado;
+  final bool castrado;
+
+  const Pet({
+    required this.id,
+    required this.nome,
+    required this.especie,
+    required this.raca,
+    required this.idade,
+    required this.sexo,
+    required this.porte,
+    required this.cidade,
+    required this.estado,
+    required this.imagemUrl,
+    this.vacinado = false,
+    this.castrado = false,
+  });
+}

--- a/mobile/lib/features/pets/presentation/bloc/favoritos_cubit.dart
+++ b/mobile/lib/features/pets/presentation/bloc/favoritos_cubit.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+
+class FavoritosState {
+  final List<Pet> favoritos;
+  const FavoritosState(this.favoritos);
+}
+
+class FavoritosCubit extends Cubit<FavoritosState> {
+  FavoritosCubit() : super(FavoritosState(_mockPets));
+
+  void toggleFavorito(Pet pet) {
+    final list = List<Pet>.from(state.favoritos);
+    if (list.any((p) => p.id == pet.id)) {
+      list.removeWhere((p) => p.id == pet.id);
+    } else {
+      list.add(pet);
+    }
+    emit(FavoritosState(list));
+  }
+
+  bool isFavorito(Pet pet) {
+    return state.favoritos.any((p) => p.id == pet.id);
+  }
+
+  static final List<Pet> _mockPets = [
+    const Pet(
+      id: '1',
+      nome: 'Pipoca',
+      especie: 'Cachorro',
+      raca: 'Golden Retriever',
+      idade: 2,
+      sexo: 'Macho',
+      porte: 'Grande',
+      cidade: 'Maringá',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1552053831-71594a27632d?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: true,
+    ),
+    const Pet(
+      id: '2',
+      nome: 'Mia',
+      especie: 'Gato',
+      raca: 'Siamês',
+      idade: 1,
+      sexo: 'Fêmea',
+      porte: 'Pequeno',
+      cidade: 'Sarandi',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: false,
+    ),
+    const Pet(
+      id: '3',
+      nome: 'Bidu',
+      especie: 'Cachorro',
+      raca: 'Poodle',
+      idade: 4,
+      sexo: 'Macho',
+      porte: 'Médio',
+      cidade: 'Maringá',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?q=80&w=400&auto=format&fit=crop',
+      vacinado: false,
+      castrado: true,
+    ),
+  ];
+}

--- a/mobile/lib/features/pets/presentation/pages/favoritos_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/favoritos_page.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/favoritos_cubit.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
+import 'package:mybuddy_app/shared/widgets/app_button.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+
+class FavoritosPage extends StatelessWidget {
+  const FavoritosPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Meus Favoritos'),
+      ),
+      body: BlocBuilder<FavoritosCubit, FavoritosState>(
+        builder: (context, state) {
+          if (state.favoritos.isEmpty) {
+            return _buildEmptyState(context, isDark, theme);
+          }
+
+          return GridView.builder(
+            padding: const EdgeInsets.all(16),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              childAspectRatio: 0.72,
+              crossAxisSpacing: 16,
+              mainAxisSpacing: 16,
+            ),
+            itemCount: state.favoritos.length,
+            itemBuilder: (context, index) {
+              final pet = state.favoritos[index];
+              return _buildPetCard(context, pet, isDark, theme);
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, bool isDark, ThemeData theme) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              height: 120,
+              width: 120,
+              decoration: BoxDecoration(
+                color: AppColors.primary.withAlpha(15),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(
+                Icons.favorite_border_rounded,
+                size: 60,
+                color: AppColors.primary,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Nenhum pet favoritado',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: isDark ? Colors.white : Colors.black87,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Os pets que você favoritar na tela inicial aparecerão aqui para fácil acesso.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                height: 1.4,
+              ),
+            ),
+            const SizedBox(height: 32),
+            AppButton(
+              text: 'Explorar Pets',
+              width: 180,
+              onPressed: () {
+                context.go('/pets');
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPetCard(BuildContext context, Pet pet, bool isDark, ThemeData theme) {
+    return AppCard(
+      padding: EdgeInsets.zero,
+      onTap: () {
+        // Para futuras implementações de detalhes (MY-330)
+      },
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Imagem do Pet com botão de desfavoritar sobreposto
+          Expanded(
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                ClipRRect(
+                  borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+                  child: Image.network(
+                    pet.imagemUrl,
+                    fit: BoxFit.cover,
+                    loadingBuilder: (context, child, loadingProgress) {
+                      if (loadingProgress == null) return child;
+                      return Center(
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          value: loadingProgress.expectedTotalBytes != null
+                              ? loadingProgress.cumulativeBytesLoaded /
+                                  loadingProgress.expectedTotalBytes!
+                              : null,
+                        ),
+                      );
+                    },
+                    errorBuilder: (context, error, stackTrace) => Container(
+                      color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                      child: const Icon(Icons.broken_image_outlined, size: 40),
+                    ),
+                  ),
+                ),
+                // Botão de Favorito (Sempre preenchido aqui porque está na tela de favoritos)
+                Positioned(
+                  top: 8,
+                  right: 8,
+                  child: Material(
+                    color: Colors.white.withAlpha(200),
+                    shape: const CircleBorder(),
+                    elevation: 2,
+                    child: IconButton(
+                      icon: const Icon(
+                        Icons.favorite_rounded,
+                        color: AppColors.primary,
+                        size: 20,
+                      ),
+                      onPressed: () {
+                        context.read<FavoritosCubit>().toggleFavorito(pet);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text('${pet.nome} foi removido dos favoritos.'),
+                            duration: const Duration(seconds: 2),
+                            action: SnackBarAction(
+                              label: 'Desfazer',
+                              onPressed: () {
+                                context.read<FavoritosCubit>().toggleFavorito(pet);
+                              },
+                            ),
+                          ),
+                        );
+                      },
+                      constraints: const BoxConstraints(),
+                      padding: const EdgeInsets.all(6),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          
+          // Dados do Pet
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        pet.nome,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: isDark ? Colors.white : Colors.black87,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Icon(
+                      pet.sexo == 'Macho' ? Icons.male_rounded : Icons.female_rounded,
+                      size: 18,
+                      color: pet.sexo == 'Macho' ? Colors.blue : Colors.pink,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  pet.raca,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                    fontWeight: FontWeight.w500,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 6),
+                Row(
+                  children: [
+                    const Icon(
+                      Icons.location_on_outlined,
+                      size: 14,
+                      color: AppColors.primary,
+                    ),
+                    const SizedBox(width: 2),
+                    Expanded(
+                      child: Text(
+                        '${pet.cidade} - ${pet.estado}',
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                          fontSize: 11,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/pets/presentation/pages/perfil_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/perfil_page.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_event.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+import 'package:mybuddy_app/shared/widgets/app_button.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+
+class PerfilPage extends StatelessWidget {
+  const PerfilPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    
+    // Pegando dados do estado de auth se estiver disponível
+    final authState = context.read<AuthBloc>().state;
+    String userName = 'Eder Henrique';
+    String userEmail = 'eder@mybuddy.com';
+
+    if (authState is AuthAuthenticated) {
+      userName = authState.user.nome;
+      userEmail = authState.user.email;
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Meu Perfil'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const SizedBox(height: 20),
+            // Avatar
+            CircleAvatar(
+              radius: 60,
+              backgroundColor: AppColors.primary.withAlpha(20),
+              child: const Icon(
+                Icons.person_rounded,
+                size: 70,
+                color: AppColors.primary,
+              ),
+            ),
+            const SizedBox(height: 20),
+            // Nome do usuário
+            Text(
+              userName,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: isDark ? Colors.white : Colors.black87,
+              ),
+            ),
+            const SizedBox(height: 4),
+            // Email do usuário
+            Text(
+              userEmail,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+              ),
+            ),
+            const SizedBox(height: 40),
+
+            // Informações adicionais fictícias para parecer completo
+            _buildProfileItem(context, Icons.edit_outlined, 'Editar Dados', isDark),
+            _buildProfileItem(context, Icons.pets_outlined, 'Meus Pets para Adoção', isDark),
+            _buildProfileItem(context, Icons.history_rounded, 'Histórico de Doações', isDark),
+            _buildProfileItem(context, Icons.settings_outlined, 'Configurações', isDark),
+
+            const SizedBox(height: 40),
+            // Botão de Sair (Logout)
+            AppButton(
+              text: 'Sair da Conta',
+              type: AppButtonType.outline,
+              onPressed: () {
+                context.read<AuthBloc>().add(LogoutRequested());
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProfileItem(BuildContext context, IconData icon, String title, bool isDark) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16.0),
+      child: Container(
+        decoration: BoxDecoration(
+          color: isDark ? AppColors.darkSurface : Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: isDark ? AppColors.darkBorder : AppColors.border,
+            width: 1,
+          ),
+        ),
+        child: ListTile(
+          leading: Icon(icon, color: AppColors.primary),
+          title: Text(
+            title,
+            style: theme.textTheme.bodyLarge?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: isDark ? Colors.white : Colors.black87,
+            ),
+          ),
+          trailing: Icon(
+            Icons.chevron_right_rounded,
+            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+          ),
+          onTap: () {
+            // Futura implementação
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/shared/theme/app_colors.dart
+++ b/mobile/lib/shared/theme/app_colors.dart
@@ -1,13 +1,35 @@
 import 'package:flutter/material.dart';
 
 class AppColors {
-  static const primary = Color(0xFFFF6B2C);
-  static const primaryDark = Color(0xFFE55A1F);
-  static const secondary = Color(0xFF2C2C2C);
-  static const background = Color(0xFFF5F5F5);
+  // Cores principais do design system (Angular)
+  static const primary = Color(0xFFFF7B00);
+  static const primaryDark = Color(0xFFE66F00); // hover/dark primary
+  static const secondary = Color(0xFF5D831C);
+  static const accent = Color(0xFF2C3E50);
+
+  // Superfícies e Backgrounds (Modo Claro)
+  static const background = Color(0xFFF4F4F4);
   static const surface = Color(0xFFFFFFFF);
+  static const border = Color(0xFFD9D9D9);
+
+  // Textos (Modo Claro)
+  static const textPrimary = Color(0xFF1E1E1E);
+  static const textSecondary = Color(0xFF2C3E50);
+  static const textLight = Color(0xFF757575);
+  static const textWhite = Color(0xFFFFFFFF);
+  static const textBlack = Color(0xFF000000);
+
+  // Semântica
   static const error = Color(0xFFDC2626);
-  static const textPrimary = Color(0xFF1A1A1A);
-  static const textSecondary = Color(0xFF6B6B6B);
-  static const border = Color(0xFFE0E0E0);
+  static const success = Color(0xFF16A34A);
+  static const warning = Color(0xFFCA8A04);
+  static const info = Color(0xFF2563EB);
+
+  // Cores adicionais para Modo Escuro (MY-336)
+  static const darkBackground = Color(0xFF121212);
+  static const darkSurface = Color(0xFF1E1E1E);
+  static const darkBorder = Color(0xFF2D2D2D);
+  static const darkTextPrimary = Color(0xFFE5E5E5);
+  static const darkTextSecondary = Color(0xFF9CA3AF);
 }
+

--- a/mobile/lib/shared/theme/app_theme.dart
+++ b/mobile/lib/shared/theme/app_theme.dart
@@ -1,47 +1,349 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:mybuddy_app/shared/theme/app_colors.dart';
 
 class AppTheme {
-  static ThemeData get light => ThemeData(
-        useMaterial3: true,
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: AppColors.primary,
-          primary: AppColors.primary,
-          surface: AppColors.surface,
-          error: AppColors.error,
+  // Configuração base do TextTheme usando Google Fonts (Inter)
+  static TextTheme _buildTextTheme(TextTheme base, Color textColor) {
+    return GoogleFonts.interTextTheme(base).copyWith(
+      displayLarge: GoogleFonts.dmSans(
+        textStyle: base.displayLarge?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.bold,
         ),
-        scaffoldBackgroundColor: AppColors.background,
-        appBarTheme: const AppBarTheme(
-          backgroundColor: AppColors.surface,
-          foregroundColor: AppColors.textPrimary,
-          elevation: 0,
-          centerTitle: true,
+      ),
+      displayMedium: GoogleFonts.dmSans(
+        textStyle: base.displayMedium?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.bold,
         ),
-        elevatedButtonTheme: ElevatedButtonThemeData(
-          style: ElevatedButton.styleFrom(
-            backgroundColor: AppColors.primary,
-            foregroundColor: Colors.white,
-            minimumSize: const Size(double.infinity, 52),
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(12),
-            ),
-          ),
+      ),
+      displaySmall: GoogleFonts.dmSans(
+        textStyle: base.displaySmall?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.bold,
         ),
-        inputDecorationTheme: InputDecorationTheme(
-          filled: true,
-          fillColor: AppColors.surface,
-          border: OutlineInputBorder(
+      ),
+      headlineLarge: GoogleFonts.dmSans(
+        textStyle: base.headlineLarge?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      headlineMedium: GoogleFonts.dmSans(
+        textStyle: base.headlineMedium?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      headlineSmall: GoogleFonts.dmSans(
+        textStyle: base.headlineSmall?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      titleLarge: GoogleFonts.dmSans(
+        textStyle: base.titleLarge?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      titleMedium: GoogleFonts.inter(
+        textStyle: base.titleMedium?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      titleSmall: GoogleFonts.inter(
+        textStyle: base.titleSmall?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      bodyLarge: GoogleFonts.inter(
+        textStyle: base.bodyLarge?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.normal,
+        ),
+      ),
+      bodyMedium: GoogleFonts.inter(
+        textStyle: base.bodyMedium?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.normal,
+        ),
+      ),
+      bodySmall: GoogleFonts.inter(
+        textStyle: base.bodySmall?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.normal,
+        ),
+      ),
+      labelLarge: GoogleFonts.inter(
+        textStyle: base.labelLarge?.copyWith(
+          color: textColor,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  // TEMA CLARO (LIGHT)
+  static ThemeData get light {
+    final base = ThemeData.light(useMaterial3: true);
+    return base.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: AppColors.primary,
+        primary: AppColors.primary,
+        secondary: AppColors.secondary,
+        tertiary: AppColors.accent,
+        surface: AppColors.surface,
+        error: AppColors.error,
+        brightness: Brightness.light,
+      ),
+      scaffoldBackgroundColor: AppColors.background,
+      textTheme: _buildTextTheme(base.textTheme, AppColors.textPrimary),
+      
+      // AppBar
+      appBarTheme: const AppBarTheme(
+        backgroundColor: AppColors.surface,
+        foregroundColor: AppColors.textPrimary,
+        elevation: 0,
+        centerTitle: true,
+        titleTextStyle: TextStyle(
+          color: AppColors.textPrimary,
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+
+      // Card
+      cardTheme: CardThemeData(
+        color: AppColors.surface,
+        elevation: 2,
+        shadowColor: const Color(0x14000000), // const Color com 8% de opacidade
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12), // --radius-md do Angular
+          side: const BorderSide(color: AppColors.border, width: 1),
+        ),
+      ),
+
+
+      // Elevated Button
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          foregroundColor: Colors.white,
+          elevation: 1,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+          minimumSize: const Size(double.infinity, 52),
+          shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
-            borderSide: const BorderSide(color: AppColors.border),
           ),
-          enabledBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: const BorderSide(color: AppColors.border),
-          ),
-          focusedBorder: OutlineInputBorder(
-            borderRadius: BorderRadius.circular(12),
-            borderSide: const BorderSide(color: AppColors.primary, width: 2),
+          textStyle: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
           ),
         ),
-      );
+      ),
+
+      // Outlined Button
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: AppColors.primary,
+          side: const BorderSide(color: AppColors.primary, width: 1.5),
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+          minimumSize: const Size(double.infinity, 52),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          textStyle: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+
+      // Text Button
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: AppColors.primary,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          textStyle: const TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+
+      // InputDecoration (Inputs de Texto)
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: AppColors.surface,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.border),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.border),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.error, width: 1.5),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.error, width: 2),
+        ),
+        labelStyle: const TextStyle(color: AppColors.textLight),
+        hintStyle: const TextStyle(color: AppColors.textLight),
+      ),
+
+      // Bottom Navigation Bar
+      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+        backgroundColor: AppColors.surface,
+        selectedItemColor: AppColors.primary,
+        unselectedItemColor: AppColors.textLight,
+        elevation: 8,
+        type: BottomNavigationBarType.fixed,
+        selectedLabelStyle: TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
+        unselectedLabelStyle: TextStyle(fontSize: 12),
+      ),
+    );
+  }
+
+  // TEMA ESCURO (DARK) - Para a tarefa MY-336
+  static ThemeData get dark {
+    final base = ThemeData.dark(useMaterial3: true);
+    return base.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: AppColors.primary,
+        primary: AppColors.primary,
+        secondary: AppColors.secondary,
+        tertiary: AppColors.accent,
+        surface: AppColors.darkSurface,
+        error: AppColors.error,
+        brightness: Brightness.dark,
+      ),
+      scaffoldBackgroundColor: AppColors.darkBackground,
+      textTheme: _buildTextTheme(base.textTheme, AppColors.darkTextPrimary),
+      
+      // AppBar
+      appBarTheme: const AppBarTheme(
+        backgroundColor: AppColors.darkSurface,
+        foregroundColor: AppColors.darkTextPrimary,
+        elevation: 0,
+        centerTitle: true,
+        titleTextStyle: TextStyle(
+          color: AppColors.darkTextPrimary,
+          fontSize: 20,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+
+      // Card
+      cardTheme: CardThemeData(
+        color: AppColors.darkSurface,
+        elevation: 2,
+        shadowColor: const Color(0x4D000000), // const Color com 30% de opacidade
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12),
+          side: const BorderSide(color: AppColors.darkBorder, width: 1),
+        ),
+      ),
+
+      // Elevated Button
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primary,
+          foregroundColor: Colors.white,
+          elevation: 1,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+          minimumSize: const Size(double.infinity, 52),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          textStyle: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+
+      // Outlined Button
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: AppColors.primary,
+          side: const BorderSide(color: AppColors.primary, width: 1.5),
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+          minimumSize: const Size(double.infinity, 52),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          textStyle: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+
+      // Text Button
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          foregroundColor: AppColors.primary,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          textStyle: const TextStyle(
+            fontSize: 15,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+
+      // InputDecoration (Inputs de Texto)
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: AppColors.darkSurface,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.darkBorder),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.darkBorder),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.primary, width: 2),
+        ),
+        errorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.error, width: 1.5),
+        ),
+        focusedErrorBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(12),
+          borderSide: const BorderSide(color: AppColors.error, width: 2),
+        ),
+        labelStyle: const TextStyle(color: AppColors.darkTextSecondary),
+        hintStyle: const TextStyle(color: AppColors.darkTextSecondary),
+      ),
+
+      // Bottom Navigation Bar
+      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+        backgroundColor: AppColors.darkSurface,
+        selectedItemColor: AppColors.primary,
+        unselectedItemColor: AppColors.darkTextSecondary,
+        elevation: 8,
+        type: BottomNavigationBarType.fixed,
+        selectedLabelStyle: TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
+        unselectedLabelStyle: TextStyle(fontSize: 12),
+      ),
+    );
+  }
 }
+

--- a/mobile/lib/shared/widgets/app_button.dart
+++ b/mobile/lib/shared/widgets/app_button.dart
@@ -3,7 +3,7 @@ import 'package:mybuddy_app/shared/theme/app_colors.dart';
 
 enum AppButtonType { primary, secondary, outline, text }
 
-class AppButton extends StatelessWidget {
+class AppButton extends StatefulWidget {
   final String text;
   final VoidCallback? onPressed;
   final bool isLoading;
@@ -26,18 +26,25 @@ class AppButton extends StatelessWidget {
   });
 
   @override
+  State<AppButton> createState() => _AppButtonState();
+}
+
+class _AppButtonState extends State<AppButton> {
+  double _scale = 1.0;
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
 
-    final isButtonDisabled = isDisabled || isLoading || onPressed == null;
+    final isButtonDisabled = widget.isDisabled || widget.isLoading || widget.onPressed == null;
 
     // Seleção de cores e estilos dependendo do tipo
     Color getBackgroundColor() {
       if (isButtonDisabled) {
         return isDark ? Colors.white12 : Colors.grey.shade300;
       }
-      switch (type) {
+      switch (widget.type) {
         case AppButtonType.primary:
           return AppColors.primary;
         case AppButtonType.secondary:
@@ -52,7 +59,7 @@ class AppButton extends StatelessWidget {
       if (isButtonDisabled) {
         return isDark ? Colors.white38 : Colors.grey.shade500;
       }
-      switch (type) {
+      switch (widget.type) {
         case AppButtonType.primary:
         case AppButtonType.secondary:
           return Colors.white;
@@ -63,7 +70,7 @@ class AppButton extends StatelessWidget {
     }
 
     BorderSide? getBorder() {
-      if (type == AppButtonType.outline) {
+      if (widget.type == AppButtonType.outline) {
         final borderColor = isButtonDisabled
             ? (isDark ? Colors.white12 : Colors.grey.shade300)
             : AppColors.primary;
@@ -76,11 +83,11 @@ class AppButton extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (icon != null && !isLoading) ...[
-          Icon(icon, size: 20, color: getForegroundColor()),
+        if (widget.icon != null && !widget.isLoading) ...[
+          Icon(widget.icon, size: 20, color: getForegroundColor()),
           const SizedBox(width: 8),
         ],
-        if (isLoading) ...[
+        if (widget.isLoading) ...[
           SizedBox(
             width: 20,
             height: 20,
@@ -92,7 +99,7 @@ class AppButton extends StatelessWidget {
           const SizedBox(width: 12),
         ],
         Text(
-          text,
+          widget.text,
           style: theme.textTheme.labelLarge?.copyWith(
             color: getForegroundColor(),
             fontSize: 16,
@@ -102,47 +109,63 @@ class AppButton extends StatelessWidget {
       ],
     );
 
-    return SizedBox(
-      width: width,
-      height: height,
-      child: type == AppButtonType.text
-          ? TextButton(
-              onPressed: isButtonDisabled ? null : onPressed,
-              style: TextButton.styleFrom(
-                foregroundColor: getForegroundColor(),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
+    return GestureDetector(
+      onTapDown: isButtonDisabled
+          ? null
+          : (_) => setState(() => _scale = 0.96),
+      onTapUp: isButtonDisabled
+          ? null
+          : (_) => setState(() => _scale = 1.0),
+      onTapCancel: isButtonDisabled
+          ? null
+          : () => setState(() => _scale = 1.0),
+      child: AnimatedScale(
+        scale: _scale,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.easeOut,
+        child: SizedBox(
+          width: widget.width,
+          height: widget.height,
+          child: widget.type == AppButtonType.text
+              ? TextButton(
+                  onPressed: isButtonDisabled ? null : widget.onPressed,
+                  style: TextButton.styleFrom(
+                    foregroundColor: getForegroundColor(),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: content,
+                )
+              : OutlinedButton(
+                  onPressed: isButtonDisabled ? null : widget.onPressed,
+                  style: OutlinedButton.styleFrom(
+                    backgroundColor: getBackgroundColor(),
+                    foregroundColor: getForegroundColor(),
+                    side: getBorder(),
+                    elevation: (widget.type == AppButtonType.outline || isButtonDisabled) ? 0 : 1,
+                    shadowColor: isDark ? Colors.black26 : Colors.black12,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ).copyWith(
+                    // Sobrescrever estado hover/press do Material 3 se necessário
+                    overlayColor: WidgetStateProperty.resolveWith<Color?>(
+                      (states) {
+                        if (states.contains(WidgetState.pressed)) {
+                          return getForegroundColor().withAlpha(20);
+                        }
+                        if (states.contains(WidgetState.hovered)) {
+                          return getForegroundColor().withAlpha(10);
+                        }
+                        return null;
+                      },
+                    ),
+                  ),
+                  child: content,
                 ),
-              ),
-              child: content,
-            )
-          : OutlinedButton(
-              onPressed: isButtonDisabled ? null : onPressed,
-              style: OutlinedButton.styleFrom(
-                backgroundColor: getBackgroundColor(),
-                foregroundColor: getForegroundColor(),
-                side: getBorder(),
-                elevation: (type == AppButtonType.outline || isButtonDisabled) ? 0 : 1,
-                shadowColor: isDark ? Colors.black26 : Colors.black12,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-              ).copyWith(
-                // Sobrescrever estado hover/press do Material 3 se necessário
-                overlayColor: WidgetStateProperty.resolveWith<Color?>(
-                  (states) {
-                    if (states.contains(WidgetState.pressed)) {
-                      return getForegroundColor().withAlpha(20);
-                    }
-                    if (states.contains(WidgetState.hovered)) {
-                      return getForegroundColor().withAlpha(10);
-                    }
-                    return null;
-                  },
-                ),
-              ),
-              child: content,
-            ),
+        ),
+      ),
     );
   }
 }

--- a/mobile/lib/shared/widgets/app_button.dart
+++ b/mobile/lib/shared/widgets/app_button.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+
+enum AppButtonType { primary, secondary, outline, text }
+
+class AppButton extends StatelessWidget {
+  final String text;
+  final VoidCallback? onPressed;
+  final bool isLoading;
+  final bool isDisabled;
+  final IconData? icon;
+  final AppButtonType type;
+  final double? width;
+  final double height;
+
+  const AppButton({
+    super.key,
+    required this.text,
+    this.onPressed,
+    this.isLoading = false,
+    this.isDisabled = false,
+    this.icon,
+    this.type = AppButtonType.primary,
+    this.width = double.infinity,
+    this.height = 52,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    final isButtonDisabled = isDisabled || isLoading || onPressed == null;
+
+    // Seleção de cores e estilos dependendo do tipo
+    Color getBackgroundColor() {
+      if (isButtonDisabled) {
+        return isDark ? Colors.white12 : Colors.grey.shade300;
+      }
+      switch (type) {
+        case AppButtonType.primary:
+          return AppColors.primary;
+        case AppButtonType.secondary:
+          return AppColors.secondary;
+        case AppButtonType.outline:
+        case AppButtonType.text:
+          return Colors.transparent;
+      }
+    }
+
+    Color getForegroundColor() {
+      if (isButtonDisabled) {
+        return isDark ? Colors.white38 : Colors.grey.shade500;
+      }
+      switch (type) {
+        case AppButtonType.primary:
+        case AppButtonType.secondary:
+          return Colors.white;
+        case AppButtonType.outline:
+        case AppButtonType.text:
+          return AppColors.primary;
+      }
+    }
+
+    BorderSide? getBorder() {
+      if (type == AppButtonType.outline) {
+        final borderColor = isButtonDisabled
+            ? (isDark ? Colors.white12 : Colors.grey.shade300)
+            : AppColors.primary;
+        return BorderSide(color: borderColor, width: 1.5);
+      }
+      return null;
+    }
+
+    Widget content = Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (icon != null && !isLoading) ...[
+          Icon(icon, size: 20, color: getForegroundColor()),
+          const SizedBox(width: 8),
+        ],
+        if (isLoading) ...[
+          SizedBox(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(getForegroundColor()),
+            ),
+          ),
+          const SizedBox(width: 12),
+        ],
+        Text(
+          text,
+          style: theme.textTheme.labelLarge?.copyWith(
+            color: getForegroundColor(),
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+
+    return SizedBox(
+      width: width,
+      height: height,
+      child: type == AppButtonType.text
+          ? TextButton(
+              onPressed: isButtonDisabled ? null : onPressed,
+              style: TextButton.styleFrom(
+                foregroundColor: getForegroundColor(),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: content,
+            )
+          : OutlinedButton(
+              onPressed: isButtonDisabled ? null : onPressed,
+              style: OutlinedButton.styleFrom(
+                backgroundColor: getBackgroundColor(),
+                foregroundColor: getForegroundColor(),
+                side: getBorder(),
+                elevation: (type == AppButtonType.outline || isButtonDisabled) ? 0 : 1,
+                shadowColor: isDark ? Colors.black26 : Colors.black12,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ).copyWith(
+                // Sobrescrever estado hover/press do Material 3 se necessário
+                overlayColor: WidgetStateProperty.resolveWith<Color?>(
+                  (states) {
+                    if (states.contains(WidgetState.pressed)) {
+                      return getForegroundColor().withAlpha(20);
+                    }
+                    if (states.contains(WidgetState.hovered)) {
+                      return getForegroundColor().withAlpha(10);
+                    }
+                    return null;
+                  },
+                ),
+              ),
+              child: content,
+            ),
+    );
+  }
+}

--- a/mobile/lib/shared/widgets/app_card.dart
+++ b/mobile/lib/shared/widgets/app_card.dart
@@ -10,6 +10,7 @@ class AppCard extends StatefulWidget {
   final EdgeInsetsGeometry padding;
   final EdgeInsetsGeometry? margin;
   final BorderSide? border;
+  final bool showShadow;
 
   const AppCard({
     super.key,
@@ -21,6 +22,7 @@ class AppCard extends StatefulWidget {
     this.padding = const EdgeInsets.all(16.0),
     this.margin,
     this.border,
+    this.showShadow = true,
   });
 
   @override
@@ -66,24 +68,30 @@ class _AppCardState extends State<AppCard> {
       );
     }
 
-    Widget result = Container(
+    final isPressed = _scale < 1.0;
+
+    Widget result = AnimatedContainer(
+      duration: const Duration(milliseconds: 100),
+      curve: Curves.easeOut,
       margin: widget.margin,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(widget.borderRadius),
-        boxShadow: [
-          BoxShadow(
-            color: shadowColor,
-            blurRadius: 6,
-            spreadRadius: -1,
-            offset: const Offset(0, 4), // --shadow-md do Angular
-          ),
-          BoxShadow(
-            color: secondaryShadowColor,
-            blurRadius: 4,
-            spreadRadius: -1,
-            offset: const Offset(0, 2),
-          ),
-        ],
+        boxShadow: widget.showShadow
+            ? [
+                BoxShadow(
+                  color: shadowColor,
+                  blurRadius: isPressed ? 3 : 6,
+                  spreadRadius: isPressed ? -1.5 : -1,
+                  offset: isPressed ? const Offset(0, 2) : const Offset(0, 4), // --shadow-md do Angular
+                ),
+                BoxShadow(
+                  color: secondaryShadowColor,
+                  blurRadius: isPressed ? 2 : 4,
+                  spreadRadius: isPressed ? -1.5 : -1,
+                  offset: isPressed ? const Offset(0, 1) : const Offset(0, 2),
+                ),
+              ]
+            : null,
       ),
       child: Material(
         color: Colors.transparent,

--- a/mobile/lib/shared/widgets/app_card.dart
+++ b/mobile/lib/shared/widgets/app_card.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:mybuddy_app/shared/theme/app_colors.dart';
 
-class AppCard extends StatelessWidget {
+class AppCard extends StatefulWidget {
   final Widget child;
   final VoidCallback? onTap;
   final Color? color;
@@ -24,23 +24,30 @@ class AppCard extends StatelessWidget {
   });
 
   @override
+  State<AppCard> createState() => _AppCardState();
+}
+
+class _AppCardState extends State<AppCard> {
+  double _scale = 1.0;
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
 
-    final cardColor = color ?? (isDark ? AppColors.darkSurface : AppColors.surface);
+    final cardColor = widget.color ?? (isDark ? AppColors.darkSurface : AppColors.surface);
     final shadowColor = isDark ? const Color(0x4D000000) : const Color(0x14000000);
     final secondaryShadowColor = isDark ? const Color(0x2E000000) : const Color(0x0C000000);
-    final defaultBorder = border ?? BorderSide(
+    final defaultBorder = widget.border ?? BorderSide(
       color: isDark ? AppColors.darkBorder : AppColors.border,
       width: 1,
     );
 
     Widget cardContent = Container(
-      padding: padding,
+      padding: widget.padding,
       decoration: BoxDecoration(
         color: cardColor,
-        borderRadius: BorderRadius.circular(borderRadius),
+        borderRadius: BorderRadius.circular(widget.borderRadius),
         border: defaultBorder != BorderSide.none ? Border(
           top: defaultBorder,
           bottom: defaultBorder,
@@ -48,21 +55,21 @@ class AppCard extends StatelessWidget {
           right: defaultBorder,
         ) : null,
       ),
-      child: child,
+      child: widget.child,
     );
 
-    if (onTap != null) {
+    if (widget.onTap != null) {
       cardContent = InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(borderRadius),
+        onTap: widget.onTap,
+        borderRadius: BorderRadius.circular(widget.borderRadius),
         child: cardContent,
       );
     }
 
-    return Container(
-      margin: margin,
+    Widget result = Container(
+      margin: widget.margin,
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(borderRadius),
+        borderRadius: BorderRadius.circular(widget.borderRadius),
         boxShadow: [
           BoxShadow(
             color: shadowColor,
@@ -83,5 +90,21 @@ class AppCard extends StatelessWidget {
         child: cardContent,
       ),
     );
+
+    if (widget.onTap != null) {
+      return GestureDetector(
+        onTapDown: (_) => setState(() => _scale = 0.98),
+        onTapUp: (_) => setState(() => _scale = 1.0),
+        onTapCancel: () => setState(() => _scale = 1.0),
+        child: AnimatedScale(
+          scale: _scale,
+          duration: const Duration(milliseconds: 100),
+          curve: Curves.easeOut,
+          child: result,
+        ),
+      );
+    }
+
+    return result;
   }
 }

--- a/mobile/lib/shared/widgets/app_card.dart
+++ b/mobile/lib/shared/widgets/app_card.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+
+class AppCard extends StatelessWidget {
+  final Widget child;
+  final VoidCallback? onTap;
+  final Color? color;
+  final double? elevation;
+  final double borderRadius;
+  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry? margin;
+  final BorderSide? border;
+
+  const AppCard({
+    super.key,
+    required this.child,
+    this.onTap,
+    this.color,
+    this.elevation,
+    this.borderRadius = 12.0, // --radius-md do Angular
+    this.padding = const EdgeInsets.all(16.0),
+    this.margin,
+    this.border,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    final cardColor = color ?? (isDark ? AppColors.darkSurface : AppColors.surface);
+    final shadowColor = isDark ? const Color(0x4D000000) : const Color(0x14000000);
+    final secondaryShadowColor = isDark ? const Color(0x2E000000) : const Color(0x0C000000);
+    final defaultBorder = border ?? BorderSide(
+      color: isDark ? AppColors.darkBorder : AppColors.border,
+      width: 1,
+    );
+
+    Widget cardContent = Container(
+      padding: padding,
+      decoration: BoxDecoration(
+        color: cardColor,
+        borderRadius: BorderRadius.circular(borderRadius),
+        border: defaultBorder != BorderSide.none ? Border(
+          top: defaultBorder,
+          bottom: defaultBorder,
+          left: defaultBorder,
+          right: defaultBorder,
+        ) : null,
+      ),
+      child: child,
+    );
+
+    if (onTap != null) {
+      cardContent = InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(borderRadius),
+        child: cardContent,
+      );
+    }
+
+    return Container(
+      margin: margin,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(borderRadius),
+        boxShadow: [
+          BoxShadow(
+            color: shadowColor,
+            blurRadius: 6,
+            spreadRadius: -1,
+            offset: const Offset(0, 4), // --shadow-md do Angular
+          ),
+          BoxShadow(
+            color: secondaryShadowColor,
+            blurRadius: 4,
+            spreadRadius: -1,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: cardContent,
+      ),
+    );
+  }
+}

--- a/mobile/lib/shared/widgets/app_input.dart
+++ b/mobile/lib/shared/widgets/app_input.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+
+class AppInput extends StatefulWidget {
+  final TextEditingController? controller;
+  final String labelText;
+  final String? hintText;
+  final bool isPassword;
+  final TextInputType keyboardType;
+  final TextInputAction textInputAction;
+  final IconData? prefixIcon;
+  final Widget? suffixIcon;
+  final String? Function(String?)? validator;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onFieldSubmitted;
+  final bool autofocus;
+  final bool enabled;
+  final int maxLines;
+
+  const AppInput({
+    super.key,
+    this.controller,
+    required this.labelText,
+    this.hintText,
+    this.isPassword = false,
+    this.keyboardType = TextInputType.text,
+    this.textInputAction = TextInputAction.next,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.validator,
+    this.onChanged,
+    this.onFieldSubmitted,
+    this.autofocus = false,
+    this.enabled = true,
+    this.maxLines = 1,
+  });
+
+  @override
+  State<AppInput> createState() => _AppInputState();
+}
+
+class _AppInputState extends State<AppInput> {
+  bool _obscureText = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _obscureText = widget.isPassword;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    Widget? getSuffixIcon() {
+      if (widget.isPassword) {
+        return IconButton(
+          icon: Icon(
+            _obscureText ? Icons.visibility_off_outlined : Icons.visibility_outlined,
+            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+          ),
+          onPressed: () {
+            setState(() {
+              _obscureText = !_obscureText;
+            });
+          },
+        );
+      }
+      return widget.suffixIcon;
+    }
+
+    return TextFormField(
+      controller: widget.controller,
+      obscureText: _obscureText,
+      keyboardType: widget.keyboardType,
+      textInputAction: widget.textInputAction,
+      validator: widget.validator,
+      onChanged: widget.onChanged,
+      onFieldSubmitted: widget.onFieldSubmitted,
+      autofocus: widget.autofocus,
+      enabled: widget.enabled,
+      maxLines: widget.isPassword ? 1 : widget.maxLines,
+      style: theme.textTheme.bodyMedium?.copyWith(
+        color: isDark ? AppColors.darkTextPrimary : AppColors.textPrimary,
+      ),
+      decoration: InputDecoration(
+        labelText: widget.labelText,
+        hintText: widget.hintText,
+        prefixIcon: widget.prefixIcon != null
+            ? Icon(
+                widget.prefixIcon,
+                color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+              )
+            : null,
+        suffixIcon: getSuffixIcon(),
+      ),
+    );
+  }
+}

--- a/mobile/lib/shared/widgets/main_scaffold.dart
+++ b/mobile/lib/shared/widgets/main_scaffold.dart
@@ -8,8 +8,10 @@ class MainScaffold extends StatelessWidget {
 
   int _currentIndex(BuildContext context) {
     final location = GoRouterState.of(context).matchedLocation;
-    if (location.startsWith('/marketplace')) return 1;
-    if (location.startsWith('/adocao')) return 2;
+    if (location.startsWith('/favoritos')) return 1;
+    if (location.startsWith('/marketplace')) return 2;
+    if (location.startsWith('/adocao')) return 3;
+    if (location.startsWith('/perfil')) return 4;
     return 0;
   }
 
@@ -19,33 +21,49 @@ class MainScaffold extends StatelessWidget {
       body: child,
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex(context),
-        selectedItemColor: Theme.of(context).colorScheme.primary,
-        unselectedItemColor: Colors.grey,
         onTap: (index) {
           switch (index) {
             case 0:
               context.go('/pets');
             case 1:
-              context.go('/marketplace');
+              context.go('/favoritos');
             case 2:
+              context.go('/marketplace');
+            case 3:
               context.go('/adocao');
+            case 4:
+              context.go('/perfil');
           }
         },
         items: const [
           BottomNavigationBarItem(
-            icon: Icon(Icons.pets),
+            icon: Icon(Icons.pets_outlined),
+            activeIcon: Icon(Icons.pets),
             label: 'Pets',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.store),
+            icon: Icon(Icons.favorite_outline_rounded),
+            activeIcon: Icon(Icons.favorite_rounded),
+            label: 'Favoritos',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.storefront_outlined),
+            activeIcon: Icon(Icons.storefront),
             label: 'Marketplace',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.favorite),
+            icon: Icon(Icons.volunteer_activism_outlined),
+            activeIcon: Icon(Icons.volunteer_activism),
             label: 'Adoção',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person_outline_rounded),
+            activeIcon: Icon(Icons.person_rounded),
+            label: 'Perfil',
           ),
         ],
       ),
     );
   }
 }
+

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -384,6 +384,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.1.3"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
   graphs:
     dependency: transitive
     description:

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
 
   # UI
   cupertino_icons: ^1.0.8
+  google_fonts: ^8.1.0
 
 dev_dependencies:
   flutter_test:

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -20,6 +20,9 @@ void main() {
 
     // Verifica que a tela de login (ou a primeira tela) é carregada
     expect(find.byType(MyBuddyApp), findsOneWidget);
+
+    // Aguarda o timer da SplashPage terminar para não deixar timers pendentes
+    await tester.pump(const Duration(seconds: 3));
   });
 }
 

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,16 +1,17 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mybuddy_app/app.dart';
 import 'package:mybuddy_app/core/constants/app_config.dart';
 import 'package:mybuddy_app/core/di/injection_container.dart' as di;
 
 void main() {
-  setUp(() async {
+  setUpAll(() async {
     // Inicializa a injeção de dependência e flavors para os testes
     AppConfig.initialize(flavorType: Flavor.dev);
     await di.init();
   });
 
-  tearDown(() async {
+  tearDownAll(() async {
     await di.sl.reset();
   });
 
@@ -22,6 +23,17 @@ void main() {
     expect(find.byType(MyBuddyApp), findsOneWidget);
 
     // Aguarda o timer da SplashPage terminar para não deixar timers pendentes
+    await tester.pump(const Duration(seconds: 3));
+  });
+
+  testWidgets('Verifica configuracao de temas claro e escuro no MaterialApp', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyBuddyApp());
+    final MaterialApp materialApp = tester.widget(find.byType(MaterialApp));
+    
+    expect(materialApp.theme?.brightness, Brightness.light);
+    expect(materialApp.darkTheme?.brightness, Brightness.dark);
+    expect(materialApp.themeMode, ThemeMode.system);
+    
     await tester.pump(const Duration(seconds: 3));
   });
 }

--- a/mobile/test/widget_test.dart
+++ b/mobile/test/widget_test.dart
@@ -1,30 +1,25 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:mybuddy_app/main.dart';
+import 'package:mybuddy_app/app.dart';
+import 'package:mybuddy_app/core/constants/app_config.dart';
+import 'package:mybuddy_app/core/di/injection_container.dart' as di;
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  setUp(() async {
+    // Inicializa a injeção de dependência e flavors para os testes
+    AppConfig.initialize(flavorType: Flavor.dev);
+    await di.init();
+  });
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+  tearDown(() async {
+    await di.sl.reset();
+  });
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+  testWidgets('Smoke test do aplicativo MyBuddy', (WidgetTester tester) async {
+    // Constrói o app e dispara o frame inicial.
+    await tester.pumpWidget(const MyBuddyApp());
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verifica que a tela de login (ou a primeira tela) é carregada
+    expect(find.byType(MyBuddyApp), findsOneWidget);
   });
 }
+


### PR DESCRIPTION
## Task Jira

- **Card:** [MY-327](https://mybuddy.atlassian.net/browse/MY-327)
- **Tipo:** Feature

---

## O que foi feito?

Adicionada a opção de autenticação via Single Sign-On (SSO) do Keycloak / OAuth2 na tela de login. Implementado um divisor visual elegante ("ou continue com"), um botão premium customizado "Entrar com Keycloak" com ícone de chave, registro do evento `LoginWithKeycloakRequested` no `AuthBloc` e integração correspondente no mock de autenticação. Além disso, foi adicionado o link de redirecionamento para a tela de Cadastro de Usuário.

---

## Escopo das mudanças

- [ ] `backend` — Java / Spring Boot
- [ ] `frontend` — Angular
- [x] `mobile` — Flutter
- [ ] `infra` — Docker / CI / configurações

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [x] Testes automatizados foram criados ou atualizados (se aplicável)

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e são reversíveis

---

## Notas para o Revisor

O login via Keycloak simula a chamada assíncrona de autenticação externa, retornando um usuário autenticado com tag `(SSO)` no mock de repositório, garantindo que o fluxo da UI e a transição para a home funcionem em sincronia com o `AuthBloc`.

---

## Como testar



[MY-327]: https://ederpontes2014.atlassian.net/browse/MY-327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ