### PR TITLE
feat(mobile): MY-337 implement UX visual review with adoption flow, m…

### DIFF
--- a/mobile/lib/app.dart
+++ b/mobile/lib/app.dart
@@ -4,7 +4,12 @@ import 'package:mybuddy_app/core/di/injection_container.dart' as di;
 import 'package:mybuddy_app/core/router/app_router.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_event.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/pets_cubit.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/favoritos_cubit.dart';
+import 'package:mybuddy_app/features/adocao/presentation/bloc/adocao_cubit.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/bloc/products_cubit.dart';
 import 'package:mybuddy_app/shared/theme/app_theme.dart';
+import 'package:mybuddy_app/shared/theme/theme_cubit.dart';
 
 class MyBuddyApp extends StatefulWidget {
   const MyBuddyApp({super.key});
@@ -25,16 +30,33 @@ class _MyBuddyAppState extends State<MyBuddyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider.value(
-      value: _authBloc,
-      child: Builder(
-        builder: (context) {
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthBloc>.value(value: _authBloc),
+        BlocProvider<FavoritosCubit>(
+          create: (context) => di.sl<FavoritosCubit>(),
+        ),
+        BlocProvider<ThemeCubit>(
+          create: (context) => di.sl<ThemeCubit>(),
+        ),
+        BlocProvider<PetsCubit>(
+          create: (context) => di.sl<PetsCubit>()..loadPets(),
+        ),
+        BlocProvider<ProductsCubit>(
+          create: (context) => di.sl<ProductsCubit>()..loadProducts(),
+        ),
+        BlocProvider<AdocaoCubit>(
+          create: (context) => di.sl<AdocaoCubit>()..loadSolicitacoes(),
+        ),
+      ],
+      child: BlocBuilder<ThemeCubit, ThemeMode>(
+        builder: (context, themeMode) {
           return MaterialApp.router(
             title: 'MyBuddy',
             debugShowCheckedModeBanner: false,
             theme: AppTheme.light,
             darkTheme: AppTheme.dark,
-            themeMode: ThemeMode.system,
+            themeMode: themeMode,
             routerConfig: AppRouter.router(context),
           );
         },

--- a/mobile/lib/core/di/injection_container.dart
+++ b/mobile/lib/core/di/injection_container.dart
@@ -4,7 +4,15 @@ import 'package:mybuddy_app/core/network/dio_client.dart';
 import 'package:mybuddy_app/features/auth/data/repositories/auth_repository_mock.dart';
 import 'package:mybuddy_app/features/auth/domain/repositories/auth_repository.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/pets/domain/repositories/pets_repository.dart';
+import 'package:mybuddy_app/features/pets/data/repositories/pets_repository_mock.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/pets_cubit.dart';
 import 'package:mybuddy_app/features/pets/presentation/bloc/favoritos_cubit.dart';
+import 'package:mybuddy_app/features/adocao/presentation/bloc/adocao_cubit.dart';
+import 'package:mybuddy_app/features/marketplace/domain/repositories/products_repository.dart';
+import 'package:mybuddy_app/features/marketplace/data/repositories/products_repository_mock.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/bloc/products_cubit.dart';
+import 'package:mybuddy_app/shared/theme/theme_cubit.dart';
 
 final sl = GetIt.instance;
 
@@ -12,29 +20,55 @@ Future<void> init() async {
   _registerCore();
   _registerAuth();
   _registerPets();
+  _registerMarketplace();
 }
 
 void _registerCore() {
   // Dio
   sl.registerLazySingleton<Dio>(() => DioClient.create());
+
+  // Theme
+  sl.registerLazySingleton<ThemeCubit>(() => ThemeCubit());
 }
 
 void _registerAuth() {
-  // BLoC — factory pra nova instância por uso
+  // BLoC
   sl.registerFactory<AuthBloc>(
     () => AuthBloc(authRepository: sl()),
   );
 
-  // Repository — mock por enquanto, trocar por impl real na MY-322
+  // Repository
   sl.registerLazySingleton<AuthRepository>(
     () => AuthRepositoryMock(),
   );
 }
 
 void _registerPets() {
-  // Cubit de favoritos persistente na sessão
+  // Repositories
+  sl.registerLazySingleton<PetsRepository>(
+    () => PetsRepositoryMock(),
+  );
+
+  // Cubits
   sl.registerLazySingleton<FavoritosCubit>(
     () => FavoritosCubit(),
   );
+  sl.registerLazySingleton<PetsCubit>(
+    () => PetsCubit(petsRepository: sl()),
+  );
+  sl.registerLazySingleton<AdocaoCubit>(
+    () => AdocaoCubit(),
+  );
 }
 
+void _registerMarketplace() {
+  // Repositories
+  sl.registerLazySingleton<ProductsRepository>(
+    () => ProductsRepositoryMock(),
+  );
+
+  // Cubits
+  sl.registerLazySingleton<ProductsCubit>(
+    () => ProductsCubit(productsRepository: sl()),
+  );
+}

--- a/mobile/lib/core/router/app_router.dart
+++ b/mobile/lib/core/router/app_router.dart
@@ -7,13 +7,21 @@ import 'package:mybuddy_app/features/auth/presentation/pages/login_page.dart';
 import 'package:mybuddy_app/features/auth/presentation/pages/splash_page.dart';
 import 'package:mybuddy_app/features/auth/presentation/pages/onboarding_page.dart';
 import 'package:mybuddy_app/features/auth/presentation/pages/cadastro_page.dart';
+import 'package:mybuddy_app/features/pets/presentation/pages/home_page.dart';
 import 'package:mybuddy_app/features/pets/presentation/pages/pets_page.dart';
 import 'package:mybuddy_app/features/pets/presentation/pages/pet_detail_page.dart';
 import 'package:mybuddy_app/features/pets/presentation/pages/favoritos_page.dart';
 import 'package:mybuddy_app/features/pets/presentation/pages/perfil_page.dart';
 import 'package:mybuddy_app/features/pets/presentation/pages/notificacoes_page.dart';
+import 'package:mybuddy_app/features/pets/presentation/pages/cadastrar_pet_page.dart';
+import 'package:mybuddy_app/features/pets/presentation/pages/meus_pets_page.dart';
+import 'package:mybuddy_app/features/adocao/presentation/pages/solicitacoes_ong_page.dart';
 import 'package:mybuddy_app/features/marketplace/presentation/pages/marketplace_page.dart';
-import 'package:mybuddy_app/features/adocao/presentation/pages/adocao_page.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/pages/cadastrar_produto_page.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/pages/meus_produtos_page.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/pages/pedidos_petshop_page.dart';
+import 'package:mybuddy_app/features/pets/presentation/pages/admin_dashboard_page.dart';
+import 'package:mybuddy_app/features/adocao/presentation/pages/eventos_page.dart';
 import 'package:mybuddy_app/shared/widgets/main_scaffold.dart';
 
 class AppRouter {
@@ -62,9 +70,9 @@ class AppRouter {
           return '/splash';
         }
 
-        // Se estiver autenticado e tentar ir para as telas de auth, manda para o feed
+        // Se estiver autenticado e tentar ir para as telas de auth, manda para a home
         if (isAuthenticated && (isSplash || isOnboarding || isLogin || isCadastro)) {
-          return '/pets';
+          return '/home';
         }
 
         return null;
@@ -99,6 +107,21 @@ class AppRouter {
           builder: (context, state, child) => MainScaffold(child: child),
           routes: [
             GoRoute(
+              path: '/home',
+              name: 'home',
+              pageBuilder: (context, state) => _fadeRoute(state, const HomePage()),
+            ),
+            GoRoute(
+              path: '/eventos',
+              name: 'eventos',
+              pageBuilder: (context, state) => _fadeRoute(state, const EventosPage()),
+            ),
+            GoRoute(
+              path: '/marketplace',
+              name: 'marketplace',
+              pageBuilder: (context, state) => _fadeRoute(state, const MarketplacePage()),
+            ),
+            GoRoute(
               path: '/pets',
               name: 'pets',
               pageBuilder: (context, state) => _fadeRoute(state, const PetsPage()),
@@ -114,26 +137,51 @@ class AppRouter {
               ],
             ),
             GoRoute(
-              path: '/favoritos',
-              name: 'favoritos',
-              pageBuilder: (context, state) => _fadeRoute(state, const FavoritosPage()),
-            ),
-            GoRoute(
-              path: '/marketplace',
-              name: 'marketplace',
-              pageBuilder: (context, state) => _fadeRoute(state, const MarketplacePage()),
-            ),
-            GoRoute(
-              path: '/adocao',
-              name: 'adocao',
-              pageBuilder: (context, state) => _fadeRoute(state, const AdocaoPage()),
-            ),
-            GoRoute(
               path: '/perfil',
               name: 'perfil',
               pageBuilder: (context, state) => _fadeRoute(state, const PerfilPage()),
             ),
           ],
+        ),
+        GoRoute(
+          path: '/favoritos',
+          name: 'favoritos',
+          pageBuilder: (context, state) => _slideRoute(state, const FavoritosPage()),
+        ),
+        GoRoute(
+          path: '/cadastrar-pet',
+          name: 'cadastrar-pet',
+          pageBuilder: (context, state) => _slideRoute(state, const CadastrarPetPage()),
+        ),
+        GoRoute(
+          path: '/meus-pets',
+          name: 'meus-pets',
+          pageBuilder: (context, state) => _slideRoute(state, const MeusPetsPage()),
+        ),
+        GoRoute(
+          path: '/solicitacoes-ong',
+          name: 'solicitacoes-ong',
+          pageBuilder: (context, state) => _slideRoute(state, const SolicitacoesOngPage()),
+        ),
+        GoRoute(
+          path: '/cadastrar-produto',
+          name: 'cadastrar-produto',
+          pageBuilder: (context, state) => _slideRoute(state, const CadastrarProdutoPage()),
+        ),
+        GoRoute(
+          path: '/meus-produtos',
+          name: 'meus-produtos',
+          pageBuilder: (context, state) => _slideRoute(state, const MeusProdutosPage()),
+        ),
+        GoRoute(
+          path: '/pedidos-petshop',
+          name: 'pedidos-petshop',
+          pageBuilder: (context, state) => _slideRoute(state, const PedidosPetshopPage()),
+        ),
+        GoRoute(
+          path: '/admin-dashboard',
+          name: 'admin-dashboard',
+          pageBuilder: (context, state) => _slideRoute(state, const AdminDashboardPage()),
         ),
       ],
       errorBuilder: (context, state) => Scaffold(
@@ -149,7 +197,7 @@ class AppRouter {
               ),
               const SizedBox(height: 8),
               TextButton(
-                onPressed: () => context.go('/pets'),
+                onPressed: () => context.go('/home'),
                 child: const Text('Voltar ao início'),
               ),
             ],

--- a/mobile/lib/features/adocao/presentation/bloc/adocao_cubit.dart
+++ b/mobile/lib/features/adocao/presentation/bloc/adocao_cubit.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+
+class SolicitacaoAdocao {
+  final String id;
+  final String petId;
+  final String petNome;
+  final String petImagemUrl;
+  final String ongId; // ID da ONG dona do pet
+  final String adotanteId; // ID do adotante
+  final String adotanteNome;
+  final String adotanteEmail;
+  final String adotanteTelefone;
+  final String data;
+  String status;
+
+  SolicitacaoAdocao({
+    required this.id,
+    required this.petId,
+    required this.petNome,
+    required this.petImagemUrl,
+    required this.ongId,
+    required this.adotanteId,
+    required this.adotanteNome,
+    required this.adotanteEmail,
+    required this.adotanteTelefone,
+    required this.data,
+    required this.status,
+  });
+}
+
+abstract class AdocaoState extends Equatable {
+  const AdocaoState();
+  @override
+  List<Object?> get props => [];
+}
+
+class AdocaoInitial extends AdocaoState {}
+
+class AdocaoLoading extends AdocaoState {}
+
+class AdocaoLoaded extends AdocaoState {
+  final List<SolicitacaoAdocao> solicitacoes;
+  const AdocaoLoaded(this.solicitacoes);
+  @override
+  List<Object?> get props => [solicitacoes];
+}
+
+class AdocaoCubit extends Cubit<AdocaoState> {
+  AdocaoCubit() : super(AdocaoInitial());
+
+  /// Mapa dinâmico: petId -> ongId
+  /// Inicializado com os pets mock; atualizado quando novos pets são cadastrados
+  final Map<String, String> _petOngMap = {
+    '1': 'ong-id-123',
+    '2': 'ong-id-123',
+    '3': 'outra-ong',
+    '4': 'outra-ong',
+    '5': 'ong-id-123',
+    '6': 'outra-ong',
+  };
+
+  final List<SolicitacaoAdocao> _solicitacoes = [
+    SolicitacaoAdocao(
+      id: '1',
+      petId: '2',
+      petNome: 'Mia',
+      petImagemUrl:
+          'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?q=80&w=400&auto=format&fit=crop',
+      ongId: 'ong-id-123',
+      adotanteId: 'adotante-id-123',
+      adotanteNome: 'Adotante MyBuddy',
+      adotanteEmail: 'user@mybuddy.com',
+      adotanteTelefone: '(44) 99999-8888',
+      data: '08/06/2026',
+      status: 'Aprovado! Aguardando Retirada',
+    ),
+    SolicitacaoAdocao(
+      id: '2',
+      petId: '1',
+      petNome: 'Pipoca',
+      petImagemUrl:
+          'https://images.unsplash.com/photo-1552053831-71594a27632d?q=80&w=400&auto=format&fit=crop',
+      ongId: 'ong-id-123',
+      adotanteId: 'adotante-id-123',
+      adotanteNome: 'Adotante MyBuddy',
+      adotanteEmail: 'user@mybuddy.com',
+      adotanteTelefone: '(44) 99999-8888',
+      data: '09/06/2026',
+      status: 'Aguardando Entrevista',
+    ),
+  ];
+
+  /// Registra a associação petId -> ongId quando um novo pet é cadastrado.
+  /// Deve ser chamado pelo [CadastrarPetPage] após cadastro bem-sucedido.
+  void registrarPetOng(String petId, String ongId) {
+    _petOngMap[petId] = ongId;
+  }
+
+  Future<void> loadSolicitacoes() async {
+    emit(AdocaoLoading());
+    await Future.delayed(const Duration(milliseconds: 150));
+    emit(AdocaoLoaded(List.from(_solicitacoes)));
+  }
+
+  /// Verifica se já existe solicitação pendente ou aprovada do adotante para este pet
+  bool jaTemSolicitacaoAtiva(String petId, String adotanteId) {
+    return _solicitacoes.any((s) =>
+        s.petId == petId &&
+        s.adotanteId == adotanteId &&
+        !s.status.contains('Recusado'));
+  }
+
+  /// Retorna apenas as solicitações de adoção para a ONG específica
+  List<SolicitacaoAdocao> getSolicitacoesPorOng(String ongId) {
+    final lista = state is AdocaoLoaded
+        ? (state as AdocaoLoaded).solicitacoes
+        : _solicitacoes;
+    return lista.where((s) => s.ongId == ongId).toList();
+  }
+
+  /// Retorna apenas as solicitações do adotante (por ID)
+  List<SolicitacaoAdocao> getSolicitacoesPorAdotante(String adotanteId) {
+    final lista = state is AdocaoLoaded
+        ? (state as AdocaoLoaded).solicitacoes
+        : _solicitacoes;
+    return lista.where((s) => s.adotanteId == adotanteId).toList();
+  }
+
+  Future<bool> solicitarAdocao({
+    required String petId,
+    required String petNome,
+    required String petImagemUrl,
+    required String clienteId,
+    required String clienteNome,
+    required String clienteEmail,
+    required String clienteTelefone,
+  }) async {
+    // Verifica duplicata antes de prosseguir
+    if (jaTemSolicitacaoAtiva(petId, clienteId)) {
+      return false; // Caller deve tratar como duplicata
+    }
+
+    await Future.delayed(const Duration(milliseconds: 400));
+    final now = DateTime.now();
+    final dataStr =
+        '${now.day.toString().padLeft(2, '0')}/${now.month.toString().padLeft(2, '0')}/${now.year}';
+
+    // Identifica a ONG dona do pet pelo mapa dinâmico; fallback para 'ong-id-123'
+    final ongId = _petOngMap[petId] ?? 'ong-id-123';
+
+    final newSolicitacao = SolicitacaoAdocao(
+      id: (DateTime.now().millisecondsSinceEpoch).toString(),
+      petId: petId,
+      petNome: petNome,
+      petImagemUrl: petImagemUrl,
+      ongId: ongId,
+      adotanteId: clienteId,
+      adotanteNome: clienteNome,
+      adotanteEmail: clienteEmail,
+      adotanteTelefone: clienteTelefone,
+      data: dataStr,
+      status: 'Aguardando Entrevista',
+    );
+
+    _solicitacoes.add(newSolicitacao);
+    await loadSolicitacoes();
+    return true;
+  }
+
+  Future<bool> atualizarStatus(String id, String novoStatus) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    final index = _solicitacoes.indexWhere((s) => s.id == id);
+    if (index != -1) {
+      _solicitacoes[index].status = novoStatus;
+      await loadSolicitacoes();
+      return true;
+    }
+    return false;
+  }
+}

--- a/mobile/lib/features/adocao/presentation/pages/eventos_page.dart
+++ b/mobile/lib/features/adocao/presentation/pages/eventos_page.dart
@@ -1,0 +1,296 @@
+import 'package:flutter/material.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
+import 'package:mybuddy_app/shared/widgets/app_button.dart';
+
+class Evento {
+  final int id;
+  final String imageUrl;
+  final String badgeText;
+  final String title;
+  final String dateStr;
+  final String timeStr;
+  final String locationStr;
+  final String organizerStr;
+  final String description;
+
+  const Evento({
+    required this.id,
+    required this.imageUrl,
+    required this.badgeText,
+    required this.title,
+    required this.dateStr,
+    required this.timeStr,
+    required this.locationStr,
+    required this.organizerStr,
+    required this.description,
+  });
+}
+
+class EventosPage extends StatefulWidget {
+  const EventosPage({super.key});
+
+  @override
+  State<EventosPage> createState() => _EventosPageState();
+}
+
+class _EventosPageState extends State<EventosPage> {
+  final List<Evento> _eventos = const [
+    Evento(
+      id: 1,
+      imageUrl: 'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?auto=format&fit=crop&q=80&w=800',
+      badgeText: 'PRÓXIMO',
+      title: "Feira de Adoção 'Amor de Pet'",
+      dateStr: 'Sábado, 25 de Maio',
+      timeStr: '10:00 - 17:00',
+      locationStr: 'Parque do Ibirapuera, SP',
+      organizerStr: 'ONG Patas Unidas',
+      description: 'Vários cachorros e gatos prontos para um novo lar. Vacinação no local e orientação veterinária gratuita.',
+    ),
+    Evento(
+      id: 2,
+      imageUrl: 'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?auto=format&fit=crop&q=80&w=800',
+      badgeText: 'EM DESTAQUE',
+      title: 'Gatoteca & Adoção de Felinos',
+      dateStr: 'Domingo, 26 de Maio',
+      timeStr: '11:00 - 16:00',
+      locationStr: 'Centro de Eventos, Curitiba',
+      organizerStr: 'ONG Felinos Felizes',
+      description: 'Venha conhecer felinos especiais procurando um lar amoroso. Lojinha de produtos artesanais para gatos no local.',
+    ),
+    Evento(
+      id: 3,
+      imageUrl: 'https://images.unsplash.com/photo-1537151608804-ea6f23b7b6c5?auto=format&fit=crop&q=80&w=800',
+      badgeText: 'NOVO',
+      title: 'Cãominhada e Feira de Adoção',
+      dateStr: 'Próximo Fim de Semana',
+      timeStr: '09:00 - 18:00',
+      locationStr: 'Lagoa do Taquaral, Campinas',
+      organizerStr: 'Coletivo Animal',
+      description: 'Caminhe com seu buddy e adote um novo amigo na nossa feira ao ar livre. Brindes especiais para os primeiros participantes.',
+    ),
+  ];
+
+  final Set<int> _confirmados = {};
+
+  void _confirmarPresenca(Evento evento) {
+    setState(() {
+      if (_confirmados.contains(evento.id)) {
+        _confirmados.remove(evento.id);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Presença cancelada no evento "${evento.title}"'),
+            backgroundColor: Colors.grey.shade800,
+          ),
+        );
+      } else {
+        _confirmados.add(evento.id);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Presença confirmada no evento "${evento.title}"!'),
+            backgroundColor: AppColors.success,
+          ),
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 20.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Eventos de Doação',
+                    style: theme.textTheme.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: isDark ? Colors.white : Colors.black87,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    'Encontre feiras, cãominhadas e eventos solidários perto de você.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Events List
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.only(left: 24.0, right: 24.0, bottom: 24.0),
+                itemCount: _eventos.length,
+                itemBuilder: (context, index) {
+                  final evento = _eventos[index];
+                  final isConfirmado = _confirmados.contains(evento.id);
+
+                  return Container(
+                    margin: const EdgeInsets.only(bottom: 24.0),
+                    child: AppCard(
+                      padding: EdgeInsets.zero,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          // Image with Badge
+                          Stack(
+                            children: [
+                              ClipRRect(
+                                borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+                                child: Image.network(
+                                  evento.imageUrl,
+                                  height: 180,
+                                  width: double.infinity,
+                                  fit: BoxFit.cover,
+                                  errorBuilder: (context, error, stackTrace) => Container(
+                                    height: 180,
+                                    color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                                    child: const Icon(Icons.broken_image_outlined, size: 50),
+                                  ),
+                                ),
+                              ),
+                              if (evento.badgeText.isNotEmpty)
+                                Positioned(
+                                  top: 12,
+                                  left: 12,
+                                  child: Container(
+                                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                                    decoration: BoxDecoration(
+                                      color: AppColors.primary,
+                                      borderRadius: BorderRadius.circular(20),
+                                    ),
+                                    child: Text(
+                                      evento.badgeText,
+                                      style: const TextStyle(
+                                        color: Colors.white,
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          ),
+
+                          // Event Details
+                          Padding(
+                            padding: const EdgeInsets.all(16.0),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  evento.title,
+                                  style: theme.textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: isDark ? Colors.white : Colors.black87,
+                                  ),
+                                ),
+                                const SizedBox(height: 12),
+
+                                // Date, time, location information
+                                _buildIconInfo(Icons.calendar_month_outlined, evento.dateStr, theme, isDark),
+                                const SizedBox(height: 6),
+                                _buildIconInfo(Icons.access_time_rounded, evento.timeStr, theme, isDark),
+                                const SizedBox(height: 6),
+                                _buildIconInfo(Icons.location_on_outlined, evento.locationStr, theme, isDark),
+                                const SizedBox(height: 6),
+                                _buildIconInfo(Icons.business_rounded, 'Organizado por: ${evento.organizerStr}', theme, isDark),
+                                
+                                const Padding(
+                                  padding: EdgeInsets.symmetric(vertical: 12.0),
+                                  child: Divider(),
+                                ),
+
+                                Text(
+                                  evento.description,
+                                  style: theme.textTheme.bodyMedium?.copyWith(
+                                    color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                    height: 1.4,
+                                  ),
+                                ),
+                                const SizedBox(height: 16),
+
+                                // Action Buttons
+                                Row(
+                                  children: [
+                                    Expanded(
+                                      child: AppButton(
+                                        text: isConfirmado ? 'Presença Confirmada!' : 'Confirmar Presença',
+                                        type: isConfirmado ? AppButtonType.outline : AppButtonType.primary,
+                                        onPressed: () => _confirmarPresenca(evento),
+                                      ),
+                                    ),
+                                    const SizedBox(width: 12),
+                                    Material(
+                                      color: isDark ? AppColors.darkSurface : Colors.grey.shade100,
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(12),
+                                        side: BorderSide(
+                                          color: isDark ? AppColors.darkBorder : AppColors.border,
+                                          width: 1,
+                                        ),
+                                      ),
+                                      child: IconButton(
+                                        icon: const Icon(Icons.map_outlined, color: AppColors.primary),
+                                        onPressed: () {
+                                          ScaffoldMessenger.of(context).showSnackBar(
+                                            SnackBar(
+                                              content: Text('Abrindo localização de "${evento.title}" no mapa...'),
+                                            ),
+                                          );
+                                        },
+                                        constraints: const BoxConstraints(),
+                                        padding: const EdgeInsets.all(12),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIconInfo(IconData icon, String text, ThemeData theme, bool isDark) {
+    return Row(
+      children: [
+        Icon(icon, size: 16, color: AppColors.primary),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+              fontSize: 12,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/adocao/presentation/pages/solicitacoes_ong_page.dart
+++ b/mobile/lib/features/adocao/presentation/pages/solicitacoes_ong_page.dart
@@ -1,0 +1,284 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+import 'package:mybuddy_app/features/adocao/presentation/bloc/adocao_cubit.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
+
+class SolicitacoesOngPage extends StatelessWidget {
+  const SolicitacoesOngPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    // Pega o ID da ONG logada
+    final authState = context.read<AuthBloc>().state;
+    String ongId = 'ong-id-123';
+    if (authState is AuthAuthenticated) {
+      ongId = authState.user.id;
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Solicitações de Adoção'),
+      ),
+      body: BlocBuilder<AdocaoCubit, AdocaoState>(
+        builder: (context, state) {
+          if (state is AdocaoLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is AdocaoLoaded) {
+            // Filtra apenas as solicitações para esta ONG
+            final solicitacoes = state.solicitacoes
+                .where((s) => s.ongId == ongId)
+                .toList();
+
+            if (solicitacoes.isEmpty) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(32.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.receipt_long_outlined, size: 72, color: Colors.grey.shade400),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Nenhuma solicitação recebida',
+                        style: theme.textTheme.titleMedium?.copyWith(color: Colors.grey),
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Quando um usuário solicitar adoção de um dos seus pets, aparecerá aqui.',
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.bodyMedium?.copyWith(color: Colors.grey.shade500),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }
+
+            // Contadores de status para o header
+            final pendentes = solicitacoes.where((s) => s.status == 'Aguardando Entrevista').length;
+            final aprovados = solicitacoes.where((s) => s.status.contains('Aprovado')).length;
+
+            return Column(
+              children: [
+                // Header com resumo
+                Container(
+                  margin: const EdgeInsets.fromLTRB(24, 16, 24, 0),
+                  padding: const EdgeInsets.all(16),
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [AppColors.primary.withAlpha(20), AppColors.secondary.withAlpha(10)],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(color: AppColors.primary.withAlpha(40)),
+                  ),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                    children: [
+                      _buildStatusCounter(context, 'Total', solicitacoes.length.toString(), Colors.blue, isDark),
+                      _buildStatusCounter(context, 'Pendentes', pendentes.toString(), Colors.orange, isDark),
+                      _buildStatusCounter(context, 'Aprovados', aprovados.toString(), AppColors.success, isDark),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Expanded(
+                  child: ListView.builder(
+                    padding: const EdgeInsets.all(24.0),
+                    itemCount: solicitacoes.length,
+                    itemBuilder: (context, index) {
+                      final solicitacao = solicitacoes[index];
+                      final bool isPendente = solicitacao.status == 'Aguardando Entrevista';
+
+                      Color statusColor = Colors.orange;
+                      if (solicitacao.status.contains('Aprovado')) statusColor = AppColors.success;
+                      if (solicitacao.status.contains('Recusado')) statusColor = Colors.red;
+
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 16.0),
+                        child: AppCard(
+                          padding: const EdgeInsets.all(16),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              // Pet details
+                              Row(
+                                children: [
+                                  ClipRRect(
+                                    borderRadius: BorderRadius.circular(10),
+                                    child: Image.network(
+                                      solicitacao.petImagemUrl,
+                                      height: 56,
+                                      width: 56,
+                                      fit: BoxFit.cover,
+                                      errorBuilder: (context, error, stackTrace) => Container(
+                                        height: 56,
+                                        width: 56,
+                                        color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                                        child: const Icon(Icons.pets, color: Colors.grey),
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          solicitacao.petNome,
+                                          style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                                        ),
+                                        const SizedBox(height: 2),
+                                        Text(
+                                          'Solicitado em: ${solicitacao.data}',
+                                          style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                    decoration: BoxDecoration(
+                                      color: statusColor.withAlpha(20),
+                                      borderRadius: BorderRadius.circular(12),
+                                      border: Border.all(color: statusColor.withAlpha(80)),
+                                    ),
+                                    child: Text(
+                                      solicitacao.status,
+                                      style: TextStyle(
+                                        color: statusColor,
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const Divider(height: 24),
+
+                              // Adotante details
+                              Text(
+                                'Interessado(a):',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  fontWeight: FontWeight.bold,
+                                  color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                ),
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                solicitacao.adotanteNome,
+                                style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600),
+                              ),
+                              const SizedBox(height: 4),
+                              Row(
+                                children: [
+                                  const Icon(Icons.email_outlined, size: 13, color: Colors.grey),
+                                  const SizedBox(width: 4),
+                                  Expanded(
+                                    child: Text(
+                                      solicitacao.adotanteEmail,
+                                      style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 2),
+                              Row(
+                                children: [
+                                  const Icon(Icons.phone_outlined, size: 13, color: Colors.grey),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    solicitacao.adotanteTelefone,
+                                    style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                                  ),
+                                ],
+                              ),
+
+                              // Action buttons if pending
+                              if (isPendente) ...[
+                                const SizedBox(height: 20),
+                                Row(
+                                  children: [
+                                    Expanded(
+                                      child: OutlinedButton.icon(
+                                        style: OutlinedButton.styleFrom(
+                                          foregroundColor: Colors.red,
+                                          side: const BorderSide(color: Colors.red),
+                                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                                          padding: const EdgeInsets.symmetric(vertical: 12),
+                                        ),
+                                        onPressed: () {
+                                          context.read<AdocaoCubit>().atualizarStatus(solicitacao.id, 'Recusado');
+                                        },
+                                        icon: const Icon(Icons.close_rounded, size: 18),
+                                        label: const Text('Recusar'),
+                                      ),
+                                    ),
+                                    const SizedBox(width: 12),
+                                    Expanded(
+                                      child: ElevatedButton.icon(
+                                        style: ElevatedButton.styleFrom(
+                                          backgroundColor: AppColors.success,
+                                          foregroundColor: Colors.white,
+                                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                                          padding: const EdgeInsets.symmetric(vertical: 12),
+                                        ),
+                                        onPressed: () {
+                                          context.read<AdocaoCubit>().atualizarStatus(solicitacao.id, 'Aprovado! Aguardando Retirada');
+                                        },
+                                        icon: const Icon(Icons.check_rounded, size: 18),
+                                        label: const Text('Aprovar'),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            );
+          }
+
+          return const Center(child: Text('Erro ao carregar solicitações.'));
+        },
+      ),
+    );
+  }
+
+  Widget _buildStatusCounter(BuildContext context, String label, String count, Color color, bool isDark) {
+    final theme = Theme.of(context);
+    return Column(
+      children: [
+        Text(
+          count,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: color,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/lib/features/auth/data/repositories/auth_repository_mock.dart
+++ b/mobile/lib/features/auth/data/repositories/auth_repository_mock.dart
@@ -11,26 +11,57 @@ class AuthRepositoryMock implements AuthRepository {
   Future<Either<Failure, User>> login(String email, String password) async {
     await Future.delayed(const Duration(seconds: 1));
 
-    if (email == 'adotante@mybuddy.com' && password == 'T1234567') {
+    if (password != 'Senha123') {
+      return const Left(AuthFailure('Senha incorreta! Use Senha123'));
+    }
+
+    if (email == 'user@mybuddy.com') {
       _currentUser = const User(
-        id: '5df8a715-5321-4dc7-b388-5325ce4253d1',
-        email: 'adotante@mybuddy.com',
+        id: 'adotante-id-123',
+        email: 'user@mybuddy.com',
         nome: 'Adotante MyBuddy',
         roles: ['ROLE_ADOTANTE'],
       );
       _isAuthenticated = true;
       return Right(_currentUser!);
+    } else if (email == 'ong@mybuddy.com') {
+      _currentUser = const User(
+        id: 'ong-id-123',
+        email: 'ong@mybuddy.com',
+        nome: 'ONG Amigo Fiel',
+        roles: ['ROLE_ONG'],
+      );
+      _isAuthenticated = true;
+      return Right(_currentUser!);
+    } else if (email == 'petshop@mybuddy.com') {
+      _currentUser = const User(
+        id: 'petshop-id-123',
+        email: 'petshop@mybuddy.com',
+        nome: 'Petshop Parceiro',
+        roles: ['ROLE_PETSHOP'],
+      );
+      _isAuthenticated = true;
+      return Right(_currentUser!);
+    } else if (email == 'admin@mybuddy.com') {
+      _currentUser = const User(
+        id: 'admin-id-123',
+        email: 'admin@mybuddy.com',
+        nome: 'Administrador Geral',
+        roles: ['ROLE_ADMIN'],
+      );
+      _isAuthenticated = true;
+      return Right(_currentUser!);
     }
 
-    return const Left(AuthFailure('Email ou senha inválidos'));
+    return const Left(AuthFailure('Email ou senha inválidos.'));
   }
 
   @override
   Future<Either<Failure, User>> loginWithKeycloak() async {
     await Future.delayed(const Duration(milliseconds: 1500));
     _currentUser = const User(
-      id: '5df8a715-5321-4dc7-b388-5325ce4253e2',
-      email: 'keycloak@mybuddy.com',
+      id: 'adotante-id-123',
+      email: 'user@mybuddy.com',
       nome: 'Eder Henrique (SSO)',
       roles: ['ROLE_ADOTANTE'],
     );
@@ -48,7 +79,7 @@ class AuthRepositoryMock implements AuthRepository {
   @override
   Future<Either<Failure, User>> getProfile() async {
     if (_currentUser != null) return Right(_currentUser!);
-    return const Left(AuthFailure('Usuário não autenticado'));
+    return const Left(AuthFailure('Usuário não autenticado.'));
   }
 
   @override

--- a/mobile/lib/features/auth/domain/entities/user.dart
+++ b/mobile/lib/features/auth/domain/entities/user.dart
@@ -16,4 +16,5 @@ class User {
   bool get isAdmin => roles.contains('ROLE_ADMIN');
   bool get isOng => roles.contains('ROLE_ONG');
   bool get isAdotante => roles.contains('ROLE_ADOTANTE');
+  bool get isPetshop => roles.contains('ROLE_PETSHOP');
 }

--- a/mobile/lib/features/auth/presentation/pages/login_page.dart
+++ b/mobile/lib/features/auth/presentation/pages/login_page.dart
@@ -41,7 +41,7 @@ class _LoginPageState extends State<LoginPage> {
     return BlocListener<AuthBloc, AuthState>(
       listener: (context, state) {
         if (state is AuthAuthenticated) {
-          context.go('/pets');
+          context.go('/home');
         } else if (state is AuthError) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(

--- a/mobile/lib/features/marketplace/data/repositories/products_repository_mock.dart
+++ b/mobile/lib/features/marketplace/data/repositories/products_repository_mock.dart
@@ -1,0 +1,104 @@
+import 'package:dartz/dartz.dart';
+import 'package:mybuddy_app/core/errors/failures.dart';
+import 'package:mybuddy_app/features/marketplace/domain/entities/produto.dart';
+import 'package:mybuddy_app/features/marketplace/domain/repositories/products_repository.dart';
+
+class ProductsRepositoryMock implements ProductsRepository {
+  final List<Produto> _produtos = [
+    const Produto(
+      id: '1',
+      nome: 'Ração Golden Duo Cães Adultos - 15kg',
+      preco: 159.90,
+      descricao: 'Alimento Premium Especial formulado para cães adultos de médio e grande porte. Sem corantes e aromatizantes artificiais.',
+      imagemUrl: 'https://images.unsplash.com/photo-1589924691126-330b1353e568?q=80&w=400&auto=format&fit=crop',
+      categoria: 'Alimentação',
+    ),
+    const Produto(
+      id: '2',
+      nome: 'Arranhador Torre com Brinquedo para Gatos',
+      preco: 89.90,
+      descricao: 'Arranhador de sisal de alta qualidade com base revestida de pelúcia macia. Ideal para o entretenimento e saúde das garras do seu gato.',
+      imagemUrl: 'https://images.unsplash.com/photo-1545249390-6bdfa286032f?q=80&w=400&auto=format&fit=crop',
+      categoria: 'Brinquedos',
+    ),
+    const Produto(
+      id: '3',
+      nome: 'Guia Retrátil para Cães - 5 Metros',
+      preco: 45.00,
+      descricao: 'Guia retrátil resistente com trava de segurança de acionamento rápido. Suporta cães de até 20kg. Empunhadura ergonômica.',
+      imagemUrl: 'https://images.unsplash.com/photo-1576201836106-db1758fd1c97?q=80&w=400&auto=format&fit=crop',
+      categoria: 'Acessórios',
+    ),
+    const Produto(
+      id: '4',
+      nome: 'Shampoo Neutro Pet Care - 500ml',
+      preco: 22.50,
+      descricao: 'Shampoo neutro hipoalergênico com extrato de aveia e mel. Deixa os pelos macios, brilhantes e fáceis de pentear. Indicado para cães e gatos.',
+      imagemUrl: 'https://images.unsplash.com/photo-1516733725897-1aa73b87c8e8?q=80&w=400&auto=format&fit=crop',
+      categoria: 'Higiene',
+    ),
+  ];
+
+  final List<PedidoCompra> _pedidos = [
+    PedidoCompra(
+      id: '1',
+      clienteNome: 'Adotante MyBuddy',
+      produtoNome: 'Guia Retrátil para Cães - 5 Metros',
+      preco: 45.00,
+      data: '10/06/2026',
+      status: 'Entregue',
+    ),
+  ];
+
+  @override
+  Future<Either<Failure, List<Produto>>> getProdutos() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return Right(List.from(_produtos));
+  }
+
+  @override
+  Future<Either<Failure, Produto>> cadastrarProduto(Produto produto) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    final newProduct = Produto(
+      id: (DateTime.now().millisecondsSinceEpoch).toString(),
+      nome: produto.nome,
+      preco: produto.preco,
+      descricao: produto.descricao,
+      imagemUrl: produto.imagemUrl.isEmpty 
+          ? 'https://images.unsplash.com/photo-1535268647977-a403b69fc756?q=80&w=400&auto=format&fit=crop'
+          : produto.imagemUrl,
+      categoria: produto.categoria,
+    );
+    _produtos.add(newProduct);
+    return Right(newProduct);
+  }
+
+  @override
+  Future<Either<Failure, List<PedidoCompra>>> getPedidos() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return Right(List.from(_pedidos));
+  }
+
+  @override
+  Future<Either<Failure, PedidoCompra>> criarPedido(PedidoCompra pedido) async {
+    await Future.delayed(const Duration(milliseconds: 400));
+    final newPedido = PedidoCompra(
+      id: (DateTime.now().millisecondsSinceEpoch).toString(),
+      clienteNome: pedido.clienteNome,
+      produtoNome: pedido.produtoNome,
+      preco: pedido.preco,
+      data: pedido.data,
+      status: pedido.status,
+    );
+    _pedidos.add(newPedido);
+    return Right(newPedido);
+  }
+
+  @override
+  Future<Either<Failure, void>> atualizarStatusPedido(String pedidoId, String status) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    final pedido = _pedidos.firstWhere((p) => p.id == pedidoId);
+    pedido.status = status;
+    return const Right(null);
+  }
+}

--- a/mobile/lib/features/marketplace/domain/entities/produto.dart
+++ b/mobile/lib/features/marketplace/domain/entities/produto.dart
@@ -1,0 +1,35 @@
+class Produto {
+  final String id;
+  final String nome;
+  final double preco;
+  final String descricao;
+  final String imagemUrl;
+  final String categoria;
+
+  const Produto({
+    required this.id,
+    required this.nome,
+    required this.preco,
+    required this.descricao,
+    required this.imagemUrl,
+    required this.categoria,
+  });
+}
+
+class PedidoCompra {
+  final String id;
+  final String clienteNome;
+  final String produtoNome;
+  final double preco;
+  final String data;
+  String status;
+
+  PedidoCompra({
+    required this.id,
+    required this.clienteNome,
+    required this.produtoNome,
+    required this.preco,
+    required this.data,
+    required this.status,
+  });
+}

--- a/mobile/lib/features/marketplace/domain/repositories/products_repository.dart
+++ b/mobile/lib/features/marketplace/domain/repositories/products_repository.dart
@@ -1,0 +1,11 @@
+import 'package:dartz/dartz.dart';
+import 'package:mybuddy_app/core/errors/failures.dart';
+import 'package:mybuddy_app/features/marketplace/domain/entities/produto.dart';
+
+abstract class ProductsRepository {
+  Future<Either<Failure, List<Produto>>> getProdutos();
+  Future<Either<Failure, Produto>> cadastrarProduto(Produto produto);
+  Future<Either<Failure, List<PedidoCompra>>> getPedidos();
+  Future<Either<Failure, PedidoCompra>> criarPedido(PedidoCompra pedido);
+  Future<Either<Failure, void>> atualizarStatusPedido(String pedidoId, String status);
+}

--- a/mobile/lib/features/marketplace/presentation/bloc/products_cubit.dart
+++ b/mobile/lib/features/marketplace/presentation/bloc/products_cubit.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:mybuddy_app/features/marketplace/domain/entities/produto.dart';
+import 'package:mybuddy_app/features/marketplace/domain/repositories/products_repository.dart';
+
+abstract class ProductsState extends Equatable {
+  const ProductsState();
+  @override
+  List<Object?> get props => [];
+}
+
+class ProductsInitial extends ProductsState {}
+class ProductsLoading extends ProductsState {}
+class ProductsLoaded extends ProductsState {
+  final List<Produto> produtos;
+  final List<PedidoCompra> pedidos;
+  const ProductsLoaded({required this.produtos, required this.pedidos});
+  
+  @override
+  List<Object?> get props => [produtos, pedidos];
+}
+class ProductsError extends ProductsState {
+  final String message;
+  const ProductsError(this.message);
+  @override
+  List<Object?> get props => [message];
+}
+
+class ProductsCubit extends Cubit<ProductsState> {
+  final ProductsRepository productsRepository;
+
+  ProductsCubit({required this.productsRepository}) : super(ProductsInitial());
+
+  Future<void> loadProducts() async {
+    emit(ProductsLoading());
+    final productsResult = await productsRepository.getProdutos();
+    final ordersResult = await productsRepository.getPedidos();
+    
+    productsResult.fold(
+      (failure) => emit(const ProductsError('Erro ao buscar produtos')),
+      (produtos) {
+        ordersResult.fold(
+          (failure) => emit(const ProductsError('Erro ao buscar pedidos')),
+          (pedidos) => emit(ProductsLoaded(produtos: produtos, pedidos: pedidos)),
+        );
+      },
+    );
+  }
+
+  Future<bool> cadastrarProduto(Produto produto) async {
+    final result = await productsRepository.cadastrarProduto(produto);
+    return result.fold(
+      (failure) => false,
+      (newProduct) {
+        loadProducts();
+        return true;
+      },
+    );
+  }
+
+  Future<bool> comprarProduto(String clienteNome, String produtoNome, double preco) async {
+    final now = DateTime.now();
+    final dataStr = '${now.day.toString().padLeft(2, '0')}/${now.month.toString().padLeft(2, '0')}/${now.year}';
+    final result = await productsRepository.criarPedido(
+      PedidoCompra(
+        id: '',
+        clienteNome: clienteNome,
+        produtoNome: produtoNome,
+        preco: preco,
+        data: dataStr,
+        status: 'Em preparação',
+      ),
+    );
+    return result.fold(
+      (failure) => false,
+      (newOrder) {
+        loadProducts();
+        return true;
+      },
+    );
+  }
+
+  Future<bool> atualizarStatusPedido(String pedidoId, String status) async {
+    final result = await productsRepository.atualizarStatusPedido(pedidoId, status);
+    return result.fold(
+      (failure) => false,
+      (_) {
+        loadProducts();
+        return true;
+      },
+    );
+  }
+}

--- a/mobile/lib/features/marketplace/presentation/pages/cadastrar_produto_page.dart
+++ b/mobile/lib/features/marketplace/presentation/pages/cadastrar_produto_page.dart
@@ -1,0 +1,178 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/marketplace/domain/entities/produto.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/bloc/products_cubit.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_button.dart';
+import 'package:mybuddy_app/shared/widgets/app_input.dart';
+
+class CadastrarProdutoPage extends StatefulWidget {
+  const CadastrarProdutoPage({super.key});
+
+  @override
+  State<CadastrarProdutoPage> createState() => _CadastrarProdutoPageState();
+}
+
+class _CadastrarProdutoPageState extends State<CadastrarProdutoPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nomeController = TextEditingController();
+  final _precoController = TextEditingController();
+  final _descricaoController = TextEditingController();
+  final _imagemUrlController = TextEditingController();
+
+  String _categoria = 'Alimentação';
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _nomeController.dispose();
+    _precoController.dispose();
+    _descricaoController.dispose();
+    _imagemUrlController.dispose();
+    super.dispose();
+  }
+
+  void _salvarProduto() async {
+    if (_formKey.currentState?.validate() ?? false) {
+      setState(() => _isLoading = true);
+
+      final produto = Produto(
+        id: '',
+        nome: _nomeController.text.trim(),
+        preco: double.parse(_precoController.text.trim().replaceAll(',', '.')),
+        descricao: _descricaoController.text.trim(),
+        imagemUrl: _imagemUrlController.text.trim(),
+        categoria: _categoria,
+      );
+
+      final success = await context.read<ProductsCubit>().cadastrarProduto(produto);
+
+      setState(() => _isLoading = false);
+
+      if (mounted) {
+        if (success) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Produto cadastrado com sucesso!'),
+              backgroundColor: AppColors.success,
+            ),
+          );
+          context.pop();
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Erro ao cadastrar produto. Tente novamente.'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cadastrar Produto'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Cadastre itens para vender no Marketplace',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // Nome
+              AppInput(
+                controller: _nomeController,
+                labelText: 'Nome do Produto',
+                prefixIcon: Icons.shopping_bag_outlined,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) return 'Informe o nome';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Preço
+              AppInput(
+                controller: _precoController,
+                labelText: 'Preço (R\$)',
+                prefixIcon: Icons.attach_money_rounded,
+                keyboardType: const TextInputType.numberWithOptions(decimal: true),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) return 'Informe o preço';
+                  final cleanVal = value.trim().replaceAll(',', '.');
+                  if (double.tryParse(cleanVal) == null) return 'Digite um preço válido';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Categoria (Dropdown)
+              DropdownButtonFormField<String>(
+                value: _categoria,
+                decoration: InputDecoration(
+                  labelText: 'Categoria',
+                  prefixIcon: const Icon(Icons.tag_rounded, color: AppColors.primary),
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'Alimentação', child: Text('Alimentação')),
+                  DropdownMenuItem(value: 'Acessórios', child: Text('Acessórios')),
+                  DropdownMenuItem(value: 'Higiene', child: Text('Higiene')),
+                  DropdownMenuItem(value: 'Brinquedos', child: Text('Brinquedos')),
+                ],
+                onChanged: (val) {
+                  if (val != null) setState(() => _categoria = val);
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Descrição
+              AppInput(
+                controller: _descricaoController,
+                labelText: 'Descrição',
+                prefixIcon: Icons.description_outlined,
+                maxLines: 3,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) return 'Informe a descrição do produto';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Imagem URL
+              AppInput(
+                controller: _imagemUrlController,
+                labelText: 'URL da Imagem (opcional)',
+                prefixIcon: Icons.image_outlined,
+                hintText: 'Link da foto na internet...',
+              ),
+              const SizedBox(height: 32),
+
+              // Botão Salvar
+              AppButton(
+                text: _isLoading ? 'Salvando...' : 'Cadastrar Produto',
+                onPressed: _isLoading ? () {} : _salvarProduto,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/marketplace/presentation/pages/marketplace_page.dart
+++ b/mobile/lib/features/marketplace/presentation/pages/marketplace_page.dart
@@ -1,14 +1,450 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+import 'package:mybuddy_app/features/marketplace/domain/entities/produto.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/bloc/products_cubit.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_button.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
 
-class MarketplacePage extends StatelessWidget {
+class MarketplacePage extends StatefulWidget {
   const MarketplacePage({super.key});
 
   @override
+  State<MarketplacePage> createState() => _MarketplacePageState();
+}
+
+class _MarketplacePageState extends State<MarketplacePage> {
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  String _selectedCategory = 'Todos';
+
+  final List<String> _categories = [
+    'Todos',
+    'Alimentação',
+    'Brinquedos',
+    'Acessórios',
+    'Higiene',
+  ];
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  void _onSearchChanged(String query) {
+    setState(() {
+      _searchQuery = query;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('Marketplace'),
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    final authState = context.read<AuthBloc>().state;
+    final loggedUser = authState is AuthAuthenticated ? authState.user : null;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Marketplace'),
+        elevation: 0,
       ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Campo de busca
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 20.0, vertical: 12.0),
+            child: Container(
+              decoration: BoxDecoration(
+                color: isDark ? AppColors.darkSurface : Colors.white,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(
+                  color: isDark ? AppColors.darkBorder : AppColors.border,
+                  width: 1.2,
+                ),
+                boxShadow: [
+                  BoxShadow(
+                    color: isDark ? Colors.black26 : Colors.black12,
+                    blurRadius: 6,
+                    offset: const Offset(0, 3),
+                  ),
+                ],
+              ),
+              child: TextField(
+                controller: _searchController,
+                onChanged: _onSearchChanged,
+                decoration: InputDecoration(
+                  hintText: 'O que seu pet precisa hoje?',
+                  hintStyle: TextStyle(
+                    color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                  ),
+                  prefixIcon: const Icon(Icons.search_rounded, color: AppColors.primary),
+                  suffixIcon: _searchQuery.isNotEmpty
+                      ? IconButton(
+                          icon: const Icon(Icons.clear_rounded, color: AppColors.primary),
+                          onPressed: () {
+                            _searchController.clear();
+                            _onSearchChanged('');
+                          },
+                        )
+                      : null,
+                  border: InputBorder.none,
+                  contentPadding: const EdgeInsets.symmetric(vertical: 14.0),
+                ),
+              ),
+            ),
+          ),
+
+          // Seletor de Categorias Horizontal
+          SizedBox(
+            height: 48,
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 16.0),
+              itemCount: _categories.length,
+              itemBuilder: (context, index) {
+                final category = _categories[index];
+                final isSelected = _selectedCategory == category;
+                return Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 6.0),
+                  child: ChoiceChip(
+                    label: Text(category),
+                    selected: isSelected,
+                    onSelected: (selected) {
+                      if (selected) {
+                        setState(() {
+                          _selectedCategory = category;
+                        });
+                      }
+                    },
+                    selectedColor: AppColors.primary,
+                    disabledColor: Colors.transparent,
+                    backgroundColor: isDark ? AppColors.darkSurface : Colors.white,
+                    labelStyle: TextStyle(
+                      color: isSelected
+                          ? Colors.white
+                          : (isDark ? AppColors.darkTextPrimary : AppColors.textPrimary),
+                      fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                      side: BorderSide(
+                        color: isSelected
+                            ? Colors.transparent
+                            : (isDark ? AppColors.darkBorder : AppColors.border),
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+
+          const SizedBox(height: 12),
+
+          // Grid de Produtos Reativo com ProductsCubit
+          Expanded(
+            child: BlocBuilder<ProductsCubit, ProductsState>(
+              builder: (context, state) {
+                if (state is ProductsLoading) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+
+                if (state is ProductsError) {
+                  return Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        const Icon(Icons.error_outline_rounded, size: 64, color: AppColors.error),
+                        const SizedBox(height: 16),
+                        Text(state.message, style: const TextStyle(fontWeight: FontWeight.bold)),
+                        const SizedBox(height: 8),
+                        ElevatedButton(
+                          onPressed: () => context.read<ProductsCubit>().loadProducts(),
+                          child: const Text('Tentar Novamente'),
+                        ),
+                      ],
+                    ),
+                  );
+                }
+
+                if (state is ProductsLoaded) {
+                  // Filtros
+                  final filteredProducts = state.produtos.where((p) {
+                    final matchesCategory = _selectedCategory == 'Todos' ||
+                        p.categoria.toLowerCase() == _selectedCategory.toLowerCase();
+                    final matchesSearch = p.nome.toLowerCase().contains(_searchQuery.toLowerCase()) ||
+                        p.descricao.toLowerCase().contains(_searchQuery.toLowerCase());
+                    return matchesCategory && matchesSearch;
+                  }).toList();
+
+                  if (filteredProducts.isEmpty) {
+                    return Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Icon(
+                            Icons.storefront_outlined,
+                            size: 72,
+                            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                          ),
+                          const SizedBox(height: 16),
+                          Text(
+                            'Nenhum produto encontrado.',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }
+
+                  return GridView.builder(
+                    padding: const EdgeInsets.all(20.0),
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      mainAxisSpacing: 16,
+                      crossAxisSpacing: 16,
+                      childAspectRatio: 0.65,
+                    ),
+                    itemCount: filteredProducts.length,
+                    itemBuilder: (context, index) {
+                      final produto = filteredProducts[index];
+                      return _buildProductCard(context, produto, loggedUser, isDark);
+                    },
+                  );
+                }
+
+                return const Center(child: Text('Carregando produtos...'));
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildProductCard(
+    BuildContext context,
+    Produto produto,
+    dynamic loggedUser,
+    bool isDark,
+  ) {
+    final theme = Theme.of(context);
+    return AppCard(
+      padding: EdgeInsets.zero,
+      borderRadius: 16,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          // Imagem do produto
+          Expanded(
+            child: ClipRRect(
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  Image.network(
+                    produto.imagemUrl,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) {
+                      return Container(
+                        color: isDark ? AppColors.darkBorder : AppColors.background,
+                        child: const Icon(
+                          Icons.shopping_bag_outlined,
+                          size: 40,
+                          color: AppColors.primary,
+                        ),
+                      );
+                    },
+                  ),
+                  Positioned(
+                    top: 8,
+                    left: 8,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: AppColors.secondary.withOpacity(0.9),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text(
+                        produto.categoria,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 10,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // Informações do produto
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  produto.nome,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    height: 1.2,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  produto.descricao,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                    fontSize: 11,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'R\$ ${produto.preco.toStringAsFixed(2).replaceAll('.', ',')}',
+                        style: const TextStyle(
+                          color: AppColors.primary,
+                          fontWeight: FontWeight.w800,
+                          fontSize: 15,
+                        ),
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(
+                        Icons.add_shopping_cart_rounded,
+                        color: AppColors.primary,
+                        size: 22,
+                      ),
+                      onPressed: () => _confirmarCompra(context, produto, loggedUser),
+                      padding: EdgeInsets.zero,
+                      constraints: const BoxConstraints(),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmarCompra(BuildContext context, Produto produto, dynamic loggedUser) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          backgroundColor: isDark ? AppColors.darkSurface : Colors.white,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+          title: const Row(
+            children: [
+              Icon(Icons.shopping_cart_checkout_rounded, color: AppColors.primary),
+              SizedBox(width: 10),
+              Text('Confirmar Compra'),
+            ],
+          ),
+          content: Text(
+            'Deseja comprar o produto "${produto.nome}" por R\$ ${produto.preco.toStringAsFixed(2).replaceAll('.', ',')}?',
+            style: TextStyle(
+              color: isDark ? AppColors.darkTextPrimary : AppColors.textPrimary,
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancelar', style: TextStyle(color: Colors.grey)),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppColors.primary,
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              ),
+              onPressed: () async {
+                Navigator.pop(context); // Fecha dialog de confirmação
+
+                // Mostrar Loading
+                showDialog(
+                  context: context,
+                  barrierDismissible: false,
+                  builder: (context) => const Center(child: CircularProgressIndicator()),
+                );
+
+                final productsCubit = context.read<ProductsCubit>();
+                final clienteNome = loggedUser?.nome ?? 'Adotante MyBuddy';
+
+                final success = await productsCubit.comprarProduto(
+                  clienteNome,
+                  produto.nome,
+                  produto.preco,
+                );
+
+                if (context.mounted) {
+                  Navigator.pop(context); // Fecha loading
+
+                  if (success) {
+                    showDialog(
+                      context: context,
+                      builder: (context) => AlertDialog(
+                        backgroundColor: isDark ? AppColors.darkSurface : Colors.white,
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+                        title: const Row(
+                          children: [
+                            Icon(Icons.check_circle_outline_rounded, color: AppColors.success),
+                            SizedBox(width: 10),
+                            Text('Sucesso!'),
+                          ],
+                        ),
+                        content: const Text(
+                          'Sua compra foi realizada com sucesso! O pedido foi enviado para o Petshop parceiro e você pode acompanhar o status em "Meu Perfil > Minhas Compras".',
+                        ),
+                        actions: [
+                          ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: AppColors.success,
+                              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                            ),
+                            onPressed: () => Navigator.pop(context),
+                            child: const Text('Ok', style: TextStyle(color: Colors.white)),
+                          ),
+                        ],
+                      ),
+                    );
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Erro ao realizar a compra. Tente novamente.'),
+                        backgroundColor: AppColors.error,
+                      ),
+                    );
+                  }
+                }
+              },
+              child: const Text('Confirmar', style: TextStyle(color: Colors.white)),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/mobile/lib/features/marketplace/presentation/pages/meus_produtos_page.dart
+++ b/mobile/lib/features/marketplace/presentation/pages/meus_produtos_page.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/bloc/products_cubit.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
+
+class MeusProdutosPage extends StatelessWidget {
+  const MeusProdutosPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Meus Produtos à Venda'),
+      ),
+      body: BlocBuilder<ProductsCubit, ProductsState>(
+        builder: (context, state) {
+          if (state is ProductsLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is ProductsLoaded) {
+            final produtos = state.produtos;
+
+            if (produtos.isEmpty) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(32.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Icons.storefront_outlined, size: 64, color: Colors.grey),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Nenhum produto cadastrado',
+                        style: theme.textTheme.titleMedium?.copyWith(color: Colors.grey),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }
+
+            return ListView.builder(
+              padding: const EdgeInsets.all(24.0),
+              itemCount: produtos.length,
+              itemBuilder: (context, index) {
+                final produto = produtos[index];
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 16.0),
+                  child: AppCard(
+                    padding: const EdgeInsets.all(12),
+                    child: Row(
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(8),
+                          child: Image.network(
+                            produto.imagemUrl,
+                            height: 70,
+                            width: 70,
+                            fit: BoxFit.cover,
+                            errorBuilder: (context, error, stackTrace) => Container(
+                              height: 70,
+                              width: 70,
+                              color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                              child: const Icon(Icons.broken_image_outlined),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 16),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                produto.nome,
+                                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                produto.categoria,
+                                style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                              ),
+                              const SizedBox(height: 6),
+                              Text(
+                                'R\$ ${produto.preco.toStringAsFixed(2)}',
+                                style: const TextStyle(
+                                  color: AppColors.primary,
+                                  fontWeight: FontWeight.bold,
+                                  fontSize: 16,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: AppColors.primary.withAlpha(20),
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: const Text(
+                            'Ativo',
+                            style: TextStyle(
+                              color: AppColors.primary,
+                              fontSize: 10,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            );
+          }
+
+          return const Center(child: Text('Erro ao carregar produtos.'));
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/marketplace/presentation/pages/pedidos_petshop_page.dart
+++ b/mobile/lib/features/marketplace/presentation/pages/pedidos_petshop_page.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/bloc/products_cubit.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
+
+class PedidosPetshopPage extends StatelessWidget {
+  const PedidosPetshopPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pedidos Recebidos'),
+      ),
+      body: BlocBuilder<ProductsCubit, ProductsState>(
+        builder: (context, state) {
+          if (state is ProductsLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (state is ProductsLoaded) {
+            final pedidos = state.pedidos;
+
+            if (pedidos.isEmpty) {
+              return Center(
+                child: Padding(
+                  padding: const EdgeInsets.all(32.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Icon(Icons.receipt_long_outlined, size: 64, color: Colors.grey),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Nenhum pedido recebido',
+                        style: theme.textTheme.titleMedium?.copyWith(color: Colors.grey),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            }
+
+            return ListView.builder(
+              padding: const EdgeInsets.all(24.0),
+              itemCount: pedidos.length,
+              itemBuilder: (context, index) {
+                final pedido = pedidos[index];
+                
+                Color statusColor = Colors.orange;
+                if (pedido.status == 'Enviado') statusColor = Colors.blue;
+                if (pedido.status == 'Entregue') statusColor = AppColors.success;
+
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 16.0),
+                  child: AppCard(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              'Pedido #${pedido.id}',
+                              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                            ),
+                            Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                              decoration: BoxDecoration(
+                                color: statusColor.withAlpha(20),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(color: statusColor.withAlpha(80)),
+                              ),
+                              child: Text(
+                                pedido.status,
+                                style: TextStyle(
+                                  color: statusColor,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          pedido.produtoNome,
+                          style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                        const SizedBox(height: 4),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              'Cliente: ${pedido.clienteNome}',
+                              style: theme.textTheme.bodyMedium?.copyWith(color: Colors.grey),
+                            ),
+                            Text(
+                              'R\$ ${pedido.preco.toStringAsFixed(2)}',
+                              style: const TextStyle(fontWeight: FontWeight.bold),
+                            ),
+                          ],
+                        ),
+                        Text(
+                          'Data da Compra: ${pedido.data}',
+                          style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                        ),
+                        
+                        // Action buttons based on current status
+                        if (pedido.status != 'Entregue') ...[
+                          const Divider(height: 24),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              if (pedido.status == 'Em preparação')
+                                ElevatedButton.icon(
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: Colors.blue,
+                                    foregroundColor: Colors.white,
+                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                                  ),
+                                  icon: const Icon(Icons.local_shipping_outlined, size: 16),
+                                  label: const Text('Marcar como Enviado'),
+                                  onPressed: () {
+                                    context.read<ProductsCubit>().atualizarStatusPedido(pedido.id, 'Enviado');
+                                  },
+                                ),
+                              if (pedido.status == 'Enviado')
+                                ElevatedButton.icon(
+                                  style: ElevatedButton.styleFrom(
+                                    backgroundColor: AppColors.success,
+                                    foregroundColor: Colors.white,
+                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                                  ),
+                                  icon: const Icon(Icons.check_circle_outline_rounded, size: 16),
+                                  label: const Text('Confirmar Entrega'),
+                                  onPressed: () {
+                                    context.read<ProductsCubit>().atualizarStatusPedido(pedido.id, 'Entregue');
+                                  },
+                                ),
+                            ],
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                );
+              },
+            );
+          }
+
+          return const Center(child: Text('Erro ao carregar pedidos.'));
+        },
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/pets/data/repositories/pets_repository_mock.dart
+++ b/mobile/lib/features/pets/data/repositories/pets_repository_mock.dart
@@ -1,0 +1,148 @@
+import 'package:dartz/dartz.dart';
+import 'package:mybuddy_app/core/errors/failures.dart';
+import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+import 'package:mybuddy_app/features/pets/domain/repositories/pets_repository.dart';
+
+class PetsRepositoryMock implements PetsRepository {
+  final List<Pet> _pets = [
+    const Pet(
+      id: '1',
+      nome: 'Pipoca',
+      especie: 'Cachorro',
+      raca: 'Golden Retriever',
+      idade: 2,
+      sexo: 'Macho',
+      porte: 'Grande',
+      cidade: 'Maringá',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1552053831-71594a27632d?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: true,
+    ),
+    const Pet(
+      id: '2',
+      nome: 'Mia',
+      especie: 'Gato',
+      raca: 'Siamês',
+      idade: 1,
+      sexo: 'Fêmea',
+      porte: 'Pequeno',
+      cidade: 'Sarandi',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: false,
+    ),
+    const Pet(
+      id: '3',
+      nome: 'Bidu',
+      especie: 'Cachorro',
+      raca: 'Poodle',
+      idade: 4,
+      sexo: 'Macho',
+      porte: 'Médio',
+      cidade: 'Maringá',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?q=80&w=400&auto=format&fit=crop',
+      vacinado: false,
+      castrado: true,
+    ),
+    const Pet(
+      id: '4',
+      nome: 'Thor',
+      especie: 'Cachorro',
+      raca: 'Pastor Alemão',
+      idade: 3,
+      sexo: 'Macho',
+      porte: 'Grande',
+      cidade: 'Londrina',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1589941013453-ec89f33b5e95?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: true,
+    ),
+    const Pet(
+      id: '5',
+      nome: 'Luna',
+      especie: 'Gato',
+      raca: 'Persa',
+      idade: 2,
+      sexo: 'Fêmea',
+      porte: 'Pequeno',
+      cidade: 'Maringá',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1618826411640-d6df44dd3f7a?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: true,
+    ),
+    const Pet(
+      id: '6',
+      nome: 'Simba',
+      especie: 'Gato',
+      raca: 'Vira-lata',
+      idade: 1,
+      sexo: 'Macho',
+      porte: 'Médio',
+      cidade: 'Paranavaí',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1519052537078-e6302a4968d4?q=80&w=400&auto=format&fit=crop',
+      vacinado: false,
+      castrado: true,
+    ),
+  ];
+
+  // Armazena quem cadastrou qual pet.
+  // Mapeia petId -> ongId.
+  final Map<String, String> _petOngMap = {
+    '1': 'ong-id-123',
+    '2': 'ong-id-123',
+    '3': 'outra-ong',
+    '4': 'outra-ong',
+    '5': 'ong-id-123',
+    '6': 'outra-ong',
+  };
+
+  @override
+  Future<Either<Failure, List<Pet>>> getPets() async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return Right(List.from(_pets));
+  }
+
+  @override
+  Future<Either<Failure, Pet>> getPetById(String id) async {
+    final pet = _pets.firstWhere((p) => p.id == id, orElse: () => _pets.first);
+    return Right(pet);
+  }
+
+  @override
+  Future<Either<Failure, Pet>> cadastrarPet(Pet pet, {String? ongId}) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    final newPet = Pet(
+      id: (DateTime.now().millisecondsSinceEpoch).toString(),
+      nome: pet.nome,
+      especie: pet.especie,
+      raca: pet.raca,
+      idade: pet.idade,
+      sexo: pet.sexo,
+      porte: pet.porte,
+      cidade: pet.cidade,
+      estado: pet.estado,
+      imagemUrl: pet.imagemUrl.isEmpty 
+          ? 'https://images.unsplash.com/photo-1543466835-00a7907e9de1?q=80&w=400&auto=format&fit=crop'
+          : pet.imagemUrl,
+      vacinado: pet.vacinado,
+      castrado: pet.castrado,
+    );
+    _pets.add(newPet);
+    // Usa o ongId passado, ou fallback para 'ong-id-123'
+    _petOngMap[newPet.id] = ongId ?? 'ong-id-123';
+    return Right(newPet);
+  }
+
+  @override
+  Future<Either<Failure, List<Pet>>> getPetsPorOng(String ongId) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    final ongPets = _pets.where((p) => _petOngMap[p.id] == ongId).toList();
+    return Right(ongPets);
+  }
+}

--- a/mobile/lib/features/pets/domain/repositories/pets_repository.dart
+++ b/mobile/lib/features/pets/domain/repositories/pets_repository.dart
@@ -1,0 +1,10 @@
+import 'package:dartz/dartz.dart';
+import 'package:mybuddy_app/core/errors/failures.dart';
+import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+
+abstract class PetsRepository {
+  Future<Either<Failure, List<Pet>>> getPets();
+  Future<Either<Failure, Pet>> getPetById(String id);
+  Future<Either<Failure, Pet>> cadastrarPet(Pet pet, {String? ongId});
+  Future<Either<Failure, List<Pet>>> getPetsPorOng(String ongId);
+}

--- a/mobile/lib/features/pets/presentation/bloc/pets_cubit.dart
+++ b/mobile/lib/features/pets/presentation/bloc/pets_cubit.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+import 'package:mybuddy_app/features/pets/domain/repositories/pets_repository.dart';
+
+abstract class PetsState extends Equatable {
+  const PetsState();
+  @override
+  List<Object?> get props => [];
+}
+
+class PetsInitial extends PetsState {}
+class PetsLoading extends PetsState {}
+class PetsLoaded extends PetsState {
+  final List<Pet> pets;
+  const PetsLoaded(this.pets);
+  @override
+  List<Object?> get props => [pets];
+}
+class PetsError extends PetsState {
+  final String message;
+  const PetsError(this.message);
+  @override
+  List<Object?> get props => [message];
+}
+
+class PetsCubit extends Cubit<PetsState> {
+  final PetsRepository petsRepository;
+  
+  PetsCubit({required this.petsRepository}) : super(PetsInitial());
+  
+  Future<void> loadPets() async {
+    emit(PetsLoading());
+    final result = await petsRepository.getPets();
+    result.fold(
+      (failure) => emit(const PetsError('Erro ao carregar os animais.')),
+      (pets) => emit(PetsLoaded(pets)),
+    );
+  }
+
+  Future<bool> cadastrarPet(Pet pet, {String? ongId}) async {
+    final result = await petsRepository.cadastrarPet(pet, ongId: ongId);
+    return result.fold(
+      (failure) => false,
+      (newPet) {
+        loadPets();
+        return true;
+      },
+    );
+  }
+
+  /// Retorna os pets cadastrados por uma ONG específica
+  Future<List<Pet>> getPetsPorOng(String ongId) async {
+    final result = await petsRepository.getPetsPorOng(ongId);
+    return result.fold(
+      (failure) => [],
+      (pets) => pets,
+    );
+  }
+}

--- a/mobile/lib/features/pets/presentation/pages/admin_dashboard_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/admin_dashboard_page.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
+
+class AdminDashboardPage extends StatefulWidget {
+  const AdminDashboardPage({super.key});
+
+  @override
+  State<AdminDashboardPage> createState() => _AdminDashboardPageState();
+}
+
+class _AdminDashboardPageState extends State<AdminDashboardPage> {
+  final List<Map<String, dynamic>> _usuarios = [
+    {'nome': 'Eder Henrique', 'email': 'eder@mybuddy.com', 'role': 'Adotante', 'ativo': true},
+    {'nome': 'ONG Amigo Fiel', 'email': 'ong@mybuddy.com', 'role': 'ONG', 'ativo': true},
+    {'nome': 'Petshop Parceiro', 'email': 'petshop@mybuddy.com', 'role': 'Petshop', 'ativo': true},
+    {'nome': 'Ana Clara', 'email': 'anaclara@mybuddy.com', 'role': 'Adotante', 'ativo': false},
+  ];
+
+  void _toggleUsuarioAtivo(int index) {
+    setState(() {
+      _usuarios[index]['ativo'] = !_usuarios[index]['ativo'];
+      final status = _usuarios[index]['ativo'] ? 'ativada' : 'desativada';
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Conta de ${_usuarios[index]['nome']} $status com sucesso!'),
+          backgroundColor: _usuarios[index]['ativo'] ? AppColors.success : Colors.orange,
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Painel Administrativo'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Grid de Métricas
+            Text(
+              'Métricas Gerais da Plataforma',
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            GridView.count(
+              crossAxisCount: 2,
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              mainAxisSpacing: 12,
+              crossAxisSpacing: 12,
+              childAspectRatio: 1.6,
+              children: [
+                _buildMetricaCard('Total Usuários', '154', Icons.people_outline_rounded, Colors.blue, isDark),
+                _buildMetricaCard('ONGs Parceiras', '18', Icons.volunteer_activism_outlined, Colors.purple, isDark),
+                _buildMetricaCard('Petshops', '12', Icons.storefront_outlined, Colors.orange, isDark),
+                _buildMetricaCard('Adoções Feitas', '34', Icons.check_circle_outline_rounded, Colors.green, isDark),
+              ],
+            ),
+            const SizedBox(height: 32),
+
+            // Lista de Usuários
+            Text(
+              'Gerenciamento de Contas',
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 12),
+            ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: _usuarios.length,
+              itemBuilder: (context, index) {
+                final user = _usuarios[index];
+                final bool ativo = user['ativo'];
+
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 12.0),
+                  child: AppCard(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              user['nome'],
+                              style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
+                            ),
+                            Text(
+                              '${user['email']} • ${user['role']}',
+                              style: theme.textTheme.bodySmall?.copyWith(color: Colors.grey),
+                            ),
+                          ],
+                        ),
+                        Switch(
+                          value: ativo,
+                          activeColor: AppColors.primary,
+                          onChanged: (_) => _toggleUsuarioAtivo(index),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMetricaCard(String title, String value, IconData icon, Color color, bool isDark) {
+    return AppCard(
+      padding: const EdgeInsets.all(12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Icon(icon, color: color, size: 24),
+              const SizedBox.shrink(),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            value,
+            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+          ),
+          Text(
+            title,
+            style: const TextStyle(color: Colors.grey, fontSize: 10),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/pets/presentation/pages/cadastrar_pet_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/cadastrar_pet_page.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/adocao/presentation/bloc/adocao_cubit.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/pets_cubit.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_button.dart';
+import 'package:mybuddy_app/shared/widgets/app_input.dart';
+
+class CadastrarPetPage extends StatefulWidget {
+  const CadastrarPetPage({super.key});
+
+  @override
+  State<CadastrarPetPage> createState() => _CadastrarPetPageState();
+}
+
+class _CadastrarPetPageState extends State<CadastrarPetPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nomeController = TextEditingController();
+  final _racaController = TextEditingController();
+  final _idadeController = TextEditingController();
+  final _cidadeController = TextEditingController();
+  final _estadoController = TextEditingController();
+  final _imagemUrlController = TextEditingController();
+
+  String _especie = 'Cachorro';
+  String _sexo = 'Macho';
+  String _porte = 'Médio';
+  bool _vacinado = false;
+  bool _castrado = false;
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _nomeController.dispose();
+    _racaController.dispose();
+    _idadeController.dispose();
+    _cidadeController.dispose();
+    _estadoController.dispose();
+    _imagemUrlController.dispose();
+    super.dispose();
+  }
+
+  void _salvarPet() async {
+    if (_formKey.currentState?.validate() ?? false) {
+      setState(() => _isLoading = true);
+
+      final pet = Pet(
+        id: '',
+        nome: _nomeController.text.trim(),
+        especie: _especie,
+        raca: _racaController.text.trim(),
+        idade: int.parse(_idadeController.text.trim()),
+        sexo: _sexo,
+        porte: _porte,
+        cidade: _cidadeController.text.trim(),
+        estado: _estadoController.text.trim().toUpperCase(),
+        imagemUrl: _imagemUrlController.text.trim(),
+        vacinado: _vacinado,
+        castrado: _castrado,
+      );
+
+      // Pega o ID da ONG logada para associar ao pet
+      final authState = context.read<AuthBloc>().state;
+      String? ongId;
+      if (authState is AuthAuthenticated) {
+        ongId = authState.user.id;
+      }
+
+      final petsCubit = context.read<PetsCubit>();
+      final adocaoCubit = context.read<AdocaoCubit>();
+
+      final success = await petsCubit.cadastrarPet(pet, ongId: ongId);
+
+      if (success && ongId != null) {
+        // Registra a associação petId -> ongId no AdocaoCubit
+        // O novo pet tem um ID gerado por timestamp; buscamos o último pet cadastrado
+        final petsState = petsCubit.state;
+        if (petsState is PetsLoaded && petsState.pets.isNotEmpty) {
+          final newPetId = petsState.pets.last.id;
+          adocaoCubit.registrarPetOng(newPetId, ongId);
+        }
+      }
+
+      setState(() => _isLoading = false);
+
+      if (mounted) {
+        if (success) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Pet cadastrado com sucesso!'),
+              backgroundColor: AppColors.success,
+            ),
+          );
+          context.pop();
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Erro ao cadastrar pet. Tente novamente.'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Cadastrar Pet'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Cadastre um novo amigo para adoção',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // Nome
+              AppInput(
+                controller: _nomeController,
+                labelText: 'Nome do Pet',
+                prefixIcon: Icons.pets_rounded,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) return 'Informe o nome do pet';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Espécie (Dropdown)
+              DropdownButtonFormField<String>(
+                value: _especie,
+                decoration: InputDecoration(
+                  labelText: 'Espécie',
+                  prefixIcon: const Icon(Icons.category_outlined, color: AppColors.primary),
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'Cachorro', child: Text('Cachorro')),
+                  DropdownMenuItem(value: 'Gato', child: Text('Gato')),
+                ],
+                onChanged: (val) {
+                  if (val != null) setState(() => _especie = val);
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Raça
+              AppInput(
+                controller: _racaController,
+                labelText: 'Raça',
+                prefixIcon: Icons.info_outline,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) return 'Informe a raça (ou escreva Vira-lata)';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Idade
+              AppInput(
+                controller: _idadeController,
+                labelText: 'Idade (em anos)',
+                prefixIcon: Icons.calendar_today_outlined,
+                keyboardType: TextInputType.number,
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) return 'Informe a idade';
+                  if (int.tryParse(value) == null) return 'Digite um número válido';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Sexo (Dropdown)
+              DropdownButtonFormField<String>(
+                value: _sexo,
+                decoration: InputDecoration(
+                  labelText: 'Sexo',
+                  prefixIcon: const Icon(Icons.transgender_outlined, color: AppColors.primary),
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'Macho', child: Text('Macho')),
+                  DropdownMenuItem(value: 'Fêmea', child: Text('Fêmea')),
+                ],
+                onChanged: (val) {
+                  if (val != null) setState(() => _sexo = val);
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Porte (Dropdown)
+              DropdownButtonFormField<String>(
+                value: _porte,
+                decoration: InputDecoration(
+                  labelText: 'Porte',
+                  prefixIcon: const Icon(Icons.height_outlined, color: AppColors.primary),
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                items: const [
+                  DropdownMenuItem(value: 'Pequeno', child: Text('Pequeno')),
+                  DropdownMenuItem(value: 'Médio', child: Text('Médio')),
+                  DropdownMenuItem(value: 'Grande', child: Text('Grande')),
+                ],
+                onChanged: (val) {
+                  if (val != null) setState(() => _porte = val);
+                },
+              ),
+              const SizedBox(height: 16),
+
+              // Cidade e Estado (Lado a Lado)
+              Row(
+                children: [
+                  Expanded(
+                    flex: 3,
+                    child: AppInput(
+                      controller: _cidadeController,
+                      labelText: 'Cidade',
+                      prefixIcon: Icons.location_city_outlined,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) return 'Cidade';
+                        return null;
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    flex: 1,
+                    child: AppInput(
+                      controller: _estadoController,
+                      labelText: 'UF',
+                      keyboardType: TextInputType.text,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) return 'UF';
+                        if (value.length != 2) return '2 letras';
+                        return null;
+                      },
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+
+              // Imagem URL
+              AppInput(
+                controller: _imagemUrlController,
+                labelText: 'URL da Imagem (opcional)',
+                prefixIcon: Icons.image_outlined,
+                hintText: 'Link da foto na internet...',
+              ),
+              const SizedBox(height: 24),
+
+              // Checkboxes de Vacinado e Castrado
+              CheckboxListTile(
+                title: const Text('O animal já está vacinado?'),
+                activeColor: AppColors.primary,
+                value: _vacinado,
+                onChanged: (val) {
+                  if (val != null) setState(() => _vacinado = val);
+                },
+                controlAffinity: ListTileControlAffinity.leading,
+                contentPadding: EdgeInsets.zero,
+              ),
+              CheckboxListTile(
+                title: const Text('O animal já está castrado?'),
+                activeColor: AppColors.primary,
+                value: _castrado,
+                onChanged: (val) {
+                  if (val != null) setState(() => _castrado = val);
+                },
+                controlAffinity: ListTileControlAffinity.leading,
+                contentPadding: EdgeInsets.zero,
+              ),
+              const SizedBox(height: 32),
+
+              // Botão Salvar
+              AppButton(
+                text: _isLoading ? 'Salvando...' : 'Cadastrar Pet',
+                onPressed: _isLoading ? () {} : _salvarPet,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/pets/presentation/pages/home_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/home_page.dart
@@ -1,0 +1,450 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/favoritos_cubit.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  static final List<Pet> _destaquePets = [
+    const Pet(
+      id: '1',
+      nome: 'Pipoca',
+      especie: 'Cachorro',
+      raca: 'Golden Retriever',
+      idade: 2,
+      sexo: 'Macho',
+      porte: 'Grande',
+      cidade: 'Maringá',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1552053831-71594a27632d?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: true,
+    ),
+    const Pet(
+      id: '2',
+      nome: 'Mia',
+      especie: 'Gato',
+      raca: 'Siamês',
+      idade: 1,
+      sexo: 'Fêmea',
+      porte: 'Pequeno',
+      cidade: 'Sarandi',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: false,
+    ),
+    const Pet(
+      id: '5',
+      nome: 'Luna',
+      especie: 'Gato',
+      raca: 'Persa',
+      idade: 2,
+      sexo: 'Fêmea',
+      porte: 'Pequeno',
+      cidade: 'Maringá',
+      estado: 'PR',
+      imagemUrl: 'https://images.unsplash.com/photo-1618826411640-d6df44dd3f7a?q=80&w=400&auto=format&fit=crop',
+      vacinado: true,
+      castrado: true,
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    // Obter nome do usuário do estado de autenticação
+    final authState = context.read<AuthBloc>().state;
+    String userName = 'Eder Henrique';
+    if (authState is AuthAuthenticated) {
+      userName = authState.user.nome;
+    }
+
+    return Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Top Bar / Boas-vindas
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 22,
+                        backgroundColor: AppColors.primary.withAlpha(20),
+                        child: const Icon(Icons.person_rounded, color: AppColors.primary),
+                      ),
+                      const SizedBox(width: 12),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Olá,',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                            ),
+                          ),
+                          Text(
+                            userName,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                              color: isDark ? Colors.white : Colors.black87,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  Container(
+                    decoration: BoxDecoration(
+                      color: isDark ? AppColors.darkSurface : Colors.white,
+                      shape: BoxShape.circle,
+                      border: Border.all(
+                        color: isDark ? AppColors.darkBorder : AppColors.border,
+                        width: 1,
+                      ),
+                    ),
+                    child: IconButton(
+                      icon: const Icon(Icons.notifications_none_rounded, color: AppColors.primary),
+                      onPressed: () => context.go('/notificacoes'),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+
+              // Banner de Destaque
+              AppCard(
+                padding: EdgeInsets.zero,
+                child: Container(
+                  width: double.infinity,
+                  height: 160,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(12),
+                    gradient: const LinearGradient(
+                      colors: [AppColors.primary, Color(0xFFFFA07A)],
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                    ),
+                  ),
+                  child: Stack(
+                    children: [
+                      Positioned(
+                        right: -10,
+                        bottom: -10,
+                        child: Icon(
+                          Icons.pets_rounded,
+                          size: 150,
+                          color: Colors.white.withAlpha(30),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.all(20.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            const Text(
+                              'Faça um novo amigo',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontSize: 20,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 6),
+                            const Text(
+                              'Adote e mude uma vida hoje.',
+                              style: TextStyle(
+                                color: Colors.white70,
+                                fontSize: 13,
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.white,
+                                foregroundColor: AppColors.primary,
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(20),
+                                ),
+                                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                              ),
+                              onPressed: () => context.go('/pets'),
+                              child: const Text(
+                                'Explorar Pets',
+                                style: TextStyle(
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 28),
+
+              // Atalhos Rápidos
+              Text(
+                'Menu Rápido',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: isDark ? Colors.white : Colors.black87,
+                ),
+              ),
+              const SizedBox(height: 12),
+              GridView.count(
+                crossAxisCount: 2,
+                shrinkWrap: true,
+                physics: const NeverScrollableScrollPhysics(),
+                mainAxisSpacing: 12,
+                crossAxisSpacing: 12,
+                childAspectRatio: 1.5,
+                children: [
+                  _buildMenuCard(
+                    context,
+                    'Adotar Pet',
+                    'Ache seu buddy',
+                    Icons.pets_rounded,
+                    AppColors.primary,
+                    () => context.go('/pets'),
+                    isDark,
+                  ),
+                  _buildMenuCard(
+                    context,
+                    'Eventos',
+                    'Feiras de adoção',
+                    Icons.event_note_rounded,
+                    Colors.orange,
+                    () => context.go('/eventos'),
+                    isDark,
+                  ),
+                  _buildMenuCard(
+                    context,
+                    'Marketplace',
+                    'Produtos de pet',
+                    Icons.storefront_rounded,
+                    Colors.blue,
+                    () => context.go('/marketplace'),
+                    isDark,
+                  ),
+                  _buildMenuCard(
+                    context,
+                    'Perfil',
+                    'Ver minha conta',
+                    Icons.person_rounded,
+                    Colors.purple,
+                    () => context.go('/perfil'),
+                    isDark,
+                  ),
+                ],
+              ),
+              const SizedBox(height: 28),
+
+              // Pets em Destaque
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    'Destaques de Adoção',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: isDark ? Colors.white : Colors.black87,
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => context.go('/pets'),
+                    child: const Text('Ver todos', style: TextStyle(color: AppColors.primary)),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              SizedBox(
+                height: 210,
+                child: ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: _destaquePets.length,
+                  itemBuilder: (context, index) {
+                    final pet = _destaquePets[index];
+                    return GestureDetector(
+                      onTap: () => context.go('/pets/${pet.id}'),
+                      child: Container(
+                        width: 140,
+                        margin: const EdgeInsets.only(right: 16),
+                        child: AppCard(
+                          padding: EdgeInsets.zero,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              Expanded(
+                                child: ClipRRect(
+                                  borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+                                  child: Image.network(
+                                    pet.imagemUrl,
+                                    fit: BoxFit.cover,
+                                    errorBuilder: (context, error, stackTrace) => Container(
+                                      color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                                      child: const Icon(Icons.broken_image_outlined),
+                                    ),
+                                  ),
+                                ),
+                              ),
+                              Padding(
+                                padding: const EdgeInsets.all(8.0),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      pet.nome,
+                                      style: theme.textTheme.bodyMedium?.copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: isDark ? Colors.white : Colors.black87,
+                                      ),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                    const SizedBox(height: 2),
+                                    Text(
+                                      '${pet.cidade} - ${pet.estado}',
+                                      style: theme.textTheme.bodySmall?.copyWith(
+                                        color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                        fontSize: 10,
+                                      ),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+              const SizedBox(height: 28),
+
+              // Dica do Dia
+              Text(
+                'Dica de Cuidado',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: isDark ? Colors.white : Colors.black87,
+                ),
+              ),
+              const SizedBox(height: 12),
+              AppCard(
+                child: Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: Colors.green.withAlpha(20),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(Icons.lightbulb_outline_rounded, color: Colors.green, size: 28),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Alimentação Saudável',
+                            style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Certifique-se de dar porções equilibradas de ração para manter o peso correto do seu buddy.',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                              height: 1.3,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMenuCard(
+    BuildContext context,
+    String title,
+    String subtitle,
+    IconData icon,
+    Color color,
+    VoidCallback onTap,
+    bool isDark,
+  ) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: AppCard(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Icon(icon, color: color, size: 28),
+                Icon(
+                  Icons.arrow_forward_rounded,
+                  color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                  size: 16,
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              title,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: isDark ? Colors.white : Colors.black87,
+              ),
+            ),
+            Text(
+              subtitle,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                fontSize: 10,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/lib/features/pets/presentation/pages/meus_pets_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/meus_pets_page.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/pets_cubit.dart';
+import 'package:mybuddy_app/shared/theme/app_colors.dart';
+import 'package:mybuddy_app/shared/widgets/app_card.dart';
+
+class MeusPetsPage extends StatefulWidget {
+  const MeusPetsPage({super.key});
+
+  @override
+  State<MeusPetsPage> createState() => _MeusPetsPageState();
+}
+
+class _MeusPetsPageState extends State<MeusPetsPage> {
+  List<Pet> _meusPets = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _carregarMeusPets();
+  }
+
+  Future<void> _carregarMeusPets() async {
+    setState(() => _isLoading = true);
+
+    final authState = context.read<AuthBloc>().state;
+    String ongId = 'ong-id-123';
+    if (authState is AuthAuthenticated) {
+      ongId = authState.user.id;
+    }
+
+    final pets = await context.read<PetsCubit>().getPetsPorOng(ongId);
+    if (mounted) {
+      setState(() {
+        _meusPets = pets;
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Meus Pets Cadastrados'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh_rounded),
+            onPressed: _carregarMeusPets,
+            tooltip: 'Atualizar lista',
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () async {
+          await context.push('/cadastrar-pet');
+          // Recarregar a lista ao voltar da tela de cadastro
+          _carregarMeusPets();
+        },
+        icon: const Icon(Icons.add_rounded),
+        label: const Text('Cadastrar Pet'),
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator())
+          : _meusPets.isEmpty
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(32.0),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(Icons.pets, size: 72, color: Colors.grey.shade400),
+                        const SizedBox(height: 16),
+                        Text(
+                          'Nenhum pet cadastrado ainda',
+                          style: theme.textTheme.titleMedium?.copyWith(color: Colors.grey),
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          'Toque no botão "Cadastrar Pet" para adicionar o primeiro!',
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyMedium?.copyWith(color: Colors.grey.shade500),
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+              : RefreshIndicator(
+                  onRefresh: _carregarMeusPets,
+                  child: ListView.builder(
+                    padding: const EdgeInsets.fromLTRB(24, 24, 24, 120),
+                    itemCount: _meusPets.length,
+                    itemBuilder: (context, index) {
+                      final pet = _meusPets[index];
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 16.0),
+                        child: AppCard(
+                          padding: const EdgeInsets.all(12),
+                          child: Row(
+                            children: [
+                              ClipRRect(
+                                borderRadius: BorderRadius.circular(10),
+                                child: Image.network(
+                                  pet.imagemUrl,
+                                  height: 75,
+                                  width: 75,
+                                  fit: BoxFit.cover,
+                                  errorBuilder: (context, error, stackTrace) => Container(
+                                    height: 75,
+                                    width: 75,
+                                    color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                                    child: const Icon(Icons.pets, color: Colors.grey),
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(width: 16),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      pet.nome,
+                                      style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                                    ),
+                                    const SizedBox(height: 4),
+                                    Text(
+                                      '${pet.especie} • ${pet.raca}',
+                                      style: theme.textTheme.bodyMedium?.copyWith(
+                                        color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 4),
+                                    Row(
+                                      children: [
+                                        const Icon(Icons.location_on_outlined, size: 12, color: AppColors.primary),
+                                        const SizedBox(width: 2),
+                                        Text(
+                                          '${pet.cidade} - ${pet.estado}',
+                                          style: theme.textTheme.bodySmall?.copyWith(
+                                            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                            fontSize: 11,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              Column(
+                                crossAxisAlignment: CrossAxisAlignment.end,
+                                children: [
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+                                    decoration: BoxDecoration(
+                                      color: Colors.green.withAlpha(20),
+                                      borderRadius: BorderRadius.circular(20),
+                                      border: Border.all(color: Colors.green.withAlpha(80)),
+                                    ),
+                                    child: const Text(
+                                      'Disponível',
+                                      style: TextStyle(
+                                        color: Colors.green,
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(height: 6),
+                                  Text(
+                                    '${pet.idade} ${pet.idade == 1 ? 'ano' : 'anos'}',
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                      fontSize: 11,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+    );
+  }
+}

--- a/mobile/lib/features/pets/presentation/pages/perfil_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/perfil_page.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/auth/domain/entities/user.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_event.dart';
 import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
+import 'package:mybuddy_app/features/adocao/presentation/bloc/adocao_cubit.dart';
+import 'package:mybuddy_app/features/marketplace/presentation/bloc/products_cubit.dart';
+import 'package:mybuddy_app/shared/theme/theme_cubit.dart';
 import 'package:mybuddy_app/shared/widgets/app_button.dart';
 import 'package:mybuddy_app/shared/widgets/app_card.dart';
 import 'package:mybuddy_app/shared/widgets/app_input.dart';
@@ -25,13 +30,27 @@ class _PerfilPageState extends State<PerfilPage> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
-    
+
+    // Sincronizar _themePreference com o estado real do ThemeCubit
+    final currentThemeMode = context.read<ThemeCubit>().state;
+    if (currentThemeMode == ThemeMode.system) {
+      _themePreference = 'Sistema';
+    } else if (currentThemeMode == ThemeMode.light) {
+      _themePreference = 'Claro';
+    } else {
+      _themePreference = 'Escuro';
+    }
+
     // Pegando dados do estado de auth se estiver disponível
     final authState = context.read<AuthBloc>().state;
-    String userName = _localName ?? 'Eder Henrique';
-    String userEmail = _localEmail ?? 'eder@mybuddy.com';
+    User? loggedUser;
+    String userId = '';
+    String userName = _localName ?? 'Adotante MyBuddy';
+    String userEmail = _localEmail ?? 'user@mybuddy.com';
 
     if (authState is AuthAuthenticated) {
+      loggedUser = authState.user;
+      userId = authState.user.id;
       userName = _localName ?? authState.user.nome;
       userEmail = _localEmail ?? authState.user.email;
     }
@@ -152,7 +171,7 @@ class _PerfilPageState extends State<PerfilPage> {
       );
     }
 
-    // Modal de Processos de Adoção
+    // Modal de Processos de Adoção (Reativo com AdocaoCubit)
     void showAdoptionProcessesModal() {
       showModalBottomSheet(
         context: context,
@@ -174,11 +193,128 @@ class _PerfilPageState extends State<PerfilPage> {
                 ),
                 const SizedBox(height: 20),
                 Expanded(
-                  child: ListView(
-                    children: [
-                      _buildProcessItem('Pipoca', 'Golden Retriever', 'Aguardando Entrevista', Colors.orange, isDark),
-                      _buildProcessItem('Mia', 'Siamês', 'Aprovado! Aguardando Retirada', Colors.green, isDark),
-                    ],
+                  child: BlocBuilder<AdocaoCubit, AdocaoState>(
+                    builder: (context, state) {
+                      if (state is AdocaoLoading) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+                      if (state is AdocaoLoaded) {
+                        // Filtra por ID do adotante (não por email, que pode ser editado localmente)
+                        final minhasSolicitacoes = userId.isNotEmpty
+                            ? state.solicitacoes.where((s) => s.adotanteId == userId).toList()
+                            : state.solicitacoes.where((s) => s.adotanteEmail == userEmail).toList();
+
+                        if (minhasSolicitacoes.isEmpty) {
+                          return const Center(
+                            child: Padding(
+                              padding: EdgeInsets.all(16.0),
+                              child: Text('Nenhum processo de adoção em andamento.'),
+                            ),
+                          );
+                        }
+
+                        return ListView.builder(
+                          itemCount: minhasSolicitacoes.length,
+                          itemBuilder: (context, idx) {
+                            final sol = minhasSolicitacoes[idx];
+                            Color statusColor = Colors.orange;
+                            if (sol.status.contains('Aprovado')) statusColor = AppColors.success;
+                            if (sol.status.contains('Recusado')) statusColor = Colors.red;
+
+                            return _buildProcessItem(sol.petNome, sol.status, statusColor, isDark);
+                          },
+                        );
+                      }
+                      return const Center(child: Text('Erro ao carregar processos.'));
+                    },
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      );
+    }
+
+    // Modal de Pedidos Realizados (Reativo com ProductsCubit)
+    void showPurchasesModal() {
+      showModalBottomSheet(
+        context: context,
+        backgroundColor: Colors.transparent,
+        builder: (context) {
+          return Container(
+            decoration: BoxDecoration(
+              color: isDark ? AppColors.darkSurface : Colors.white,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+            ),
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text(
+                  'Minhas Compras',
+                  style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 20),
+                Expanded(
+                  child: BlocBuilder<ProductsCubit, ProductsState>(
+                    builder: (context, state) {
+                      if (state is ProductsLoading) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+                      if (state is ProductsLoaded) {
+                        final minhasCompras = state.pedidos.where((p) => p.clienteNome == userName).toList();
+
+                        if (minhasCompras.isEmpty) {
+                          return const Center(
+                            child: Padding(
+                              padding: EdgeInsets.all(16.0),
+                              child: Text('Nenhuma compra realizada no Marketplace.'),
+                            ),
+                          );
+                        }
+
+                        return ListView.builder(
+                          itemCount: minhasCompras.length,
+                          itemBuilder: (context, idx) {
+                            final comp = minhasCompras[idx];
+                            Color statusColor = Colors.orange;
+                            if (comp.status == 'Enviado') statusColor = Colors.blue;
+                            if (comp.status == 'Entregue') statusColor = AppColors.success;
+
+                            return Container(
+                              margin: const EdgeInsets.only(bottom: 12),
+                              padding: const EdgeInsets.all(16),
+                              decoration: BoxDecoration(
+                                color: isDark ? AppColors.darkBackground : AppColors.background,
+                                borderRadius: BorderRadius.circular(12),
+                              ),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(comp.produtoNome, style: const TextStyle(fontWeight: FontWeight.bold), maxLines: 1, overflow: TextOverflow.ellipsis),
+                                        const SizedBox(height: 4),
+                                        Text('Status: ${comp.status}', style: TextStyle(color: statusColor, fontWeight: FontWeight.bold, fontSize: 12)),
+                                      ],
+                                    ),
+                                  ),
+                                  Text(
+                                    'R\$ ${comp.preco.toStringAsFixed(2)}',
+                                    style: const TextStyle(fontWeight: FontWeight.bold),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        );
+                      }
+                      return const Center(child: Text('Erro ao carregar compras.'));
+                    },
                   ),
                 ),
               ],
@@ -215,7 +351,8 @@ class _PerfilPageState extends State<PerfilPage> {
                     SwitchListTile(
                       title: const Text('Notificações Push'),
                       subtitle: const Text('Receba avisos de adoções e ofertas'),
-                      activeColor: AppColors.primary,
+                      activeThumbColor: AppColors.primary,
+                      activeTrackColor: AppColors.primary.withAlpha(100),
                       value: _notificationsEnabled,
                       onChanged: (value) {
                         setModalState(() {
@@ -245,6 +382,17 @@ class _PerfilPageState extends State<PerfilPage> {
                             setState(() {
                               _themePreference = value;
                             });
+
+                            ThemeMode mode;
+                            if (value == 'Sistema') {
+                              mode = ThemeMode.system;
+                            } else if (value == 'Claro') {
+                              mode = ThemeMode.light;
+                            } else {
+                              mode = ThemeMode.dark;
+                            }
+                            context.read<ThemeCubit>().updateTheme(mode);
+
                             ScaffoldMessenger.of(context).showSnackBar(
                               SnackBar(
                                 content: Text('Preferência de tema alterada para: $value'),
@@ -301,13 +449,59 @@ class _PerfilPageState extends State<PerfilPage> {
                 color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
               ),
             ),
-            const SizedBox(height: 40),
+            const SizedBox(height: 32),
 
-            // Itens interativos do perfil
-            _buildProfileItem(context, Icons.edit_outlined, 'Editar Dados', showEditProfileModal, isDark),
-            _buildProfileItem(context, Icons.pets_outlined, 'Meus Processos de Adoção', showAdoptionProcessesModal, isDark),
-            _buildProfileItem(context, Icons.history_rounded, 'Histórico de Doações', showDonationHistoryModal, isDark),
-            _buildProfileItem(context, Icons.settings_outlined, 'Configurações', showSettingsModal, isDark),
+            // Exibir badge do perfil
+            if (loggedUser != null) ...[
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                decoration: BoxDecoration(
+                  color: AppColors.primary.withAlpha(20),
+                  borderRadius: BorderRadius.circular(20),
+                  border: Border.all(color: AppColors.primary.withAlpha(80)),
+                ),
+                child: Text(
+                  loggedUser.isOng 
+                      ? 'PERFIL ONG' 
+                      : (loggedUser.isPetshop 
+                          ? 'PERFIL PETSHOP' 
+                          : (loggedUser.isAdmin ? 'ADMINISTRADOR' : 'PERFIL ADOTANTE')),
+                  style: const TextStyle(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 11,
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // Itens interativos do perfil de acordo com a Role
+            if (loggedUser != null && loggedUser.isOng) ...[
+              _buildProfileItem(context, Icons.edit_outlined, 'Editar Dados', showEditProfileModal, isDark),
+              _buildProfileItem(context, Icons.add_circle_outline_rounded, 'Cadastrar Novo Pet', () => context.push('/cadastrar-pet'), isDark),
+              _buildProfileItem(context, Icons.pets_outlined, 'Meus Pets Cadastrados', () => context.push('/meus-pets'), isDark),
+              _buildProfileItem(context, Icons.receipt_long_outlined, 'Solicitações de Adoção', () => context.push('/solicitacoes-ong'), isDark),
+              _buildProfileItem(context, Icons.settings_outlined, 'Configurações', showSettingsModal, isDark),
+            ] else if (loggedUser != null && loggedUser.isPetshop) ...[
+              _buildProfileItem(context, Icons.edit_outlined, 'Editar Dados', showEditProfileModal, isDark),
+              _buildProfileItem(context, Icons.add_business_outlined, 'Cadastrar Novo Produto', () => context.push('/cadastrar-produto'), isDark),
+              _buildProfileItem(context, Icons.storefront_outlined, 'Meus Produtos à Venda', () => context.push('/meus-produtos'), isDark),
+              _buildProfileItem(context, Icons.receipt_long_outlined, 'Pedidos Recebidos', () => context.push('/pedidos-petshop'), isDark),
+              _buildProfileItem(context, Icons.settings_outlined, 'Configurações', showSettingsModal, isDark),
+            ] else if (loggedUser != null && loggedUser.isAdmin) ...[
+              _buildProfileItem(context, Icons.edit_outlined, 'Editar Dados', showEditProfileModal, isDark),
+              _buildProfileItem(context, Icons.dashboard_outlined, 'Painel Administrativo', () => context.push('/admin-dashboard'), isDark),
+              _buildProfileItem(context, Icons.settings_outlined, 'Configurações', showSettingsModal, isDark),
+            ] else ...[
+              // Adotante (ou Padrão)
+              _buildProfileItem(context, Icons.edit_outlined, 'Editar Dados', showEditProfileModal, isDark),
+              _buildProfileItem(context, Icons.favorite_outline_rounded, 'Meus Favoritos', () => context.push('/favoritos'), isDark),
+              _buildProfileItem(context, Icons.pets_outlined, 'Meus Processos de Adoção', showAdoptionProcessesModal, isDark),
+              _buildProfileItem(context, Icons.shopping_bag_outlined, 'Minhas Compras', showPurchasesModal, isDark),
+              _buildProfileItem(context, Icons.history_rounded, 'Histórico de Doações', showDonationHistoryModal, isDark),
+              _buildProfileItem(context, Icons.settings_outlined, 'Configurações', showSettingsModal, isDark),
+            ],
 
             const SizedBox(height: 40),
             // Botão de Sair (Logout)
@@ -382,7 +576,7 @@ class _PerfilPageState extends State<PerfilPage> {
     );
   }
 
-  Widget _buildProcessItem(String name, String breed, String status, Color statusColor, bool isDark) {
+  Widget _buildProcessItem(String name, String status, Color statusColor, bool isDark) {
     return Container(
       margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(16),
@@ -401,7 +595,7 @@ class _PerfilPageState extends State<PerfilPage> {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('$name ($breed)', style: const TextStyle(fontWeight: FontWeight.bold)),
+                Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
                 const SizedBox(height: 4),
                 Text(
                   status,

--- a/mobile/lib/features/pets/presentation/pages/pet_detail_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/pet_detail_page.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:mybuddy_app/features/auth/presentation/bloc/auth_state.dart';
 import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/pets_cubit.dart';
 import 'package:mybuddy_app/features/pets/presentation/bloc/favoritos_cubit.dart';
+import 'package:mybuddy_app/features/adocao/presentation/bloc/adocao_cubit.dart';
 import 'package:mybuddy_app/shared/widgets/app_button.dart';
 import 'package:mybuddy_app/shared/widgets/app_card.dart';
 import 'package:mybuddy_app/shared/theme/app_colors.dart';
@@ -12,364 +16,401 @@ class PetDetailPage extends StatelessWidget {
 
   const PetDetailPage({super.key, required this.petId});
 
-  static final List<Pet> _allPets = [
-    const Pet(
-      id: '1',
-      nome: 'Pipoca',
-      especie: 'Cachorro',
-      raca: 'Golden Retriever',
-      idade: 2,
-      sexo: 'Macho',
-      porte: 'Grande',
-      cidade: 'Maringá',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1552053831-71594a27632d?q=80&w=400&auto=format&fit=crop',
-      vacinado: true,
-      castrado: true,
-    ),
-    const Pet(
-      id: '2',
-      nome: 'Mia',
-      especie: 'Gato',
-      raca: 'Siamês',
-      idade: 1,
-      sexo: 'Fêmea',
-      porte: 'Pequeno',
-      cidade: 'Sarandi',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?q=80&w=400&auto=format&fit=crop',
-      vacinado: true,
-      castrado: false,
-    ),
-    const Pet(
-      id: '3',
-      nome: 'Bidu',
-      especie: 'Cachorro',
-      raca: 'Poodle',
-      idade: 4,
-      sexo: 'Macho',
-      porte: 'Médio',
-      cidade: 'Maringá',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?q=80&w=400&auto=format&fit=crop',
-      vacinado: false,
-      castrado: true,
-    ),
-    const Pet(
-      id: '4',
-      nome: 'Thor',
-      especie: 'Cachorro',
-      raca: 'Pastor Alemão',
-      idade: 3,
-      sexo: 'Macho',
-      porte: 'Grande',
-      cidade: 'Londrina',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1589941013453-ec89f33b5e95?q=80&w=400&auto=format&fit=crop',
-      vacinado: true,
-      castrado: true,
-    ),
-    const Pet(
-      id: '5',
-      nome: 'Luna',
-      especie: 'Gato',
-      raca: 'Persa',
-      idade: 2,
-      sexo: 'Fêmea',
-      porte: 'Pequeno',
-      cidade: 'Maringá',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1618826411640-d6df44dd3f7a?q=80&w=400&auto=format&fit=crop',
-      vacinado: true,
-      castrado: true,
-    ),
-    const Pet(
-      id: '6',
-      nome: 'Simba',
-      especie: 'Gato',
-      raca: 'Vira-lata',
-      idade: 1,
-      sexo: 'Macho',
-      porte: 'Médio',
-      cidade: 'Paranavaí',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1519052537078-e6302a4968d4?q=80&w=400&auto=format&fit=crop',
-      vacinado: false,
-      castrado: true,
-    ),
-  ];
-
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isDark = theme.brightness == Brightness.dark;
 
-    final pet = _allPets.firstWhere(
-      (p) => p.id == petId,
-      orElse: () => _allPets.first,
-    );
+    return BlocBuilder<PetsCubit, PetsState>(
+      builder: (context, petsState) {
+        Pet? pet;
+        if (petsState is PetsLoaded && petsState.pets.isNotEmpty) {
+          // Procura pelo ID exato; se não encontrar, retorna null (não usa fallback arriscado)
+          try {
+            pet = petsState.pets.firstWhere((p) => p.id == petId);
+          } catch (_) {
+            pet = null;
+          }
+        }
 
-    void showAdoptionDialog() {
-      showModalBottomSheet(
-        context: context,
-        backgroundColor: Colors.transparent,
-        builder: (context) {
-          return Container(
-            decoration: BoxDecoration(
-              color: isDark ? AppColors.darkSurface : Colors.white,
-              borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+        if (pet == null) {
+          return Scaffold(
+            appBar: AppBar(),
+            body: const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.error_outline, size: 64, color: Colors.grey),
+                  SizedBox(height: 16),
+                  Text('Pet não encontrado', style: TextStyle(color: Colors.grey)),
+                ],
+              ),
             ),
-            padding: const EdgeInsets.all(32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Container(
-                  width: 50,
-                  height: 5,
-                  decoration: BoxDecoration(
-                    color: Colors.grey.shade300,
-                    borderRadius: BorderRadius.circular(10),
+          );
+        }
+
+        // Obter dados do usuário logado
+        final authState = context.read<AuthBloc>().state;
+        String clienteId = '';
+        String clienteNome = 'Visitante';
+        String clienteEmail = '';
+        bool isOng = false;
+        bool isLoggedIn = false;
+
+        if (authState is AuthAuthenticated) {
+          clienteId = authState.user.id;
+          clienteNome = authState.user.nome;
+          clienteEmail = authState.user.email;
+          isOng = authState.user.isOng;
+          isLoggedIn = true;
+        }
+
+        final currentPet = pet;
+
+        void showAdoptionDialog() async {
+          if (!isLoggedIn) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Faça login para solicitar adoção.'),
+                backgroundColor: Colors.orange,
+              ),
+            );
+            return;
+          }
+
+          // Verifica se já tem solicitação ativa para este pet
+          final adocaoCubit = context.read<AdocaoCubit>();
+          if (adocaoCubit.jaTemSolicitacaoAtiva(currentPet.id, clienteId)) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Você já possui uma solicitação ativa para este pet!'),
+                backgroundColor: Colors.orange,
+              ),
+            );
+            return;
+          }
+
+          // Mostra diálogo de confirmação antes de submeter
+          final confirmed = await showDialog<bool>(
+            context: context,
+            builder: (ctx) => AlertDialog(
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+              title: const Text('Confirmar Solicitação'),
+              content: Text(
+                'Você deseja solicitar a adoção de ${currentPet.nome}?\n\nA ONG responsável entrará em contato pelo email:\n$clienteEmail',
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx, false),
+                  child: const Text('Cancelar'),
+                ),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: Colors.white,
                   ),
-                ),
-                const SizedBox(height: 24),
-                const Icon(Icons.volunteer_activism_rounded, size: 72, color: AppColors.primary),
-                const SizedBox(height: 16),
-                Text(
-                  'Solicitação Enviada!',
-                  style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
-                ),
-                const SizedBox(height: 12),
-                Text(
-                  'A ONG responsável pelo(a) ${pet.nome} foi notificada e entrará em contato com você em breve para realizar a entrevista de adoção.',
-                  textAlign: TextAlign.center,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
-                    height: 1.4,
-                  ),
-                ),
-                const SizedBox(height: 32),
-                AppButton(
-                  text: 'Entendido',
-                  onPressed: () {
-                    Navigator.pop(context);
-                    context.go('/pets');
-                  },
+                  onPressed: () => Navigator.pop(ctx, true),
+                  child: const Text('Confirmar'),
                 ),
               ],
             ),
           );
-        },
-      );
-    }
 
-    return Scaffold(
-      body: Stack(
-        children: [
-          // Background/Scrollable Content
-          SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                // Hero Image
-                Hero(
-                  tag: 'pet_img_${pet.id}',
-                  child: Image.network(
-                    pet.imagemUrl,
-                    height: 380,
-                    fit: BoxFit.cover,
+          if (confirmed != true || !context.mounted) return;
+
+          final success = await adocaoCubit.solicitarAdocao(
+            petId: currentPet.id,
+            petNome: currentPet.nome,
+            petImagemUrl: currentPet.imagemUrl,
+            clienteId: clienteId,
+            clienteNome: clienteNome,
+            clienteEmail: clienteEmail,
+            clienteTelefone: '(44) 99999-0000',
+          );
+
+          if (!context.mounted) return;
+
+          if (success) {
+            showModalBottomSheet(
+              context: context,
+              backgroundColor: Colors.transparent,
+              isScrollControlled: true,
+              builder: (context) {
+                return Container(
+                  decoration: BoxDecoration(
+                    color: isDark ? AppColors.darkSurface : Colors.white,
+                    borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
                   ),
-                ),
-                
-                // Pet Info Overlay Container
-                Transform.translate(
-                  offset: const Offset(0, -20),
-                  child: Container(
-                    decoration: BoxDecoration(
-                      color: isDark ? AppColors.darkBackground : AppColors.background,
-                      borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-                    ),
-                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // Name & Gender
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  pet.nome,
-                                  style: theme.textTheme.headlineMedium?.copyWith(
-                                    fontWeight: FontWeight.bold,
-                                    color: isDark ? Colors.white : Colors.black87,
-                                  ),
-                                ),
-                                const SizedBox(height: 4),
-                                Row(
-                                  children: [
-                                    const Icon(Icons.location_on_outlined, size: 16, color: AppColors.primary),
-                                    const SizedBox(width: 4),
-                                    Text(
-                                      '${pet.cidade} - ${pet.estado}',
-                                      style: theme.textTheme.bodyMedium?.copyWith(
-                                        color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                            Icon(
-                              pet.sexo == 'Macho' ? Icons.male_rounded : Icons.female_rounded,
-                              size: 32,
-                              color: pet.sexo == 'Macho' ? Colors.blue : Colors.pink,
-                            ),
-                          ],
+                  padding: const EdgeInsets.fromLTRB(32, 24, 32, 48),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Container(
+                        width: 40,
+                        height: 4,
+                        decoration: BoxDecoration(
+                          color: Colors.grey.shade300,
+                          borderRadius: BorderRadius.circular(10),
                         ),
-                        const SizedBox(height: 24),
-                        
-                        // Technical specs row
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            _buildSpecCard(context, 'Raça', pet.raca, isDark),
-                            _buildSpecCard(context, 'Idade', '${pet.idade} ${pet.idade == 1 ? 'ano' : 'anos'}', isDark),
-                            _buildSpecCard(context, 'Porte', pet.porte, isDark),
-                          ],
+                      ),
+                      const SizedBox(height: 24),
+                      const Icon(Icons.volunteer_activism_rounded, size: 72, color: AppColors.primary),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Solicitação Enviada!',
+                        style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'A ONG responsável pelo(a) ${currentPet.nome} foi notificada e entrará em contato com você em breve para realizar a entrevista de adoção.',
+                        textAlign: TextAlign.center,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                          height: 1.5,
                         ),
-                        const SizedBox(height: 32),
-
-                        // Vaccine & Castration Badges
-                        Row(
-                          children: [
-                            if (pet.vacinado)
-                              _buildBadge(context, 'Vacinado', Icons.check_circle_outline, Colors.green),
-                            if (!pet.vacinado)
-                              _buildBadge(context, 'Vacina Pendente', Icons.info_outline, Colors.orange),
-                            const SizedBox(width: 12),
-                            if (pet.castrado)
-                              _buildBadge(context, 'Castrado', Icons.check_circle_outline, Colors.green),
-                            if (!pet.castrado)
-                              _buildBadge(context, 'Não Castrado', Icons.info_outline, Colors.orange),
-                          ],
-                        ),
-                        const SizedBox(height: 32),
-
-                        // About description
-                        Text(
-                          'Sobre mim',
-                          style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-                        ),
-                        const SizedBox(height: 12),
-                        Text(
-                          'Olá! Sou o(a) ${pet.nome}, um(a) lindo(a) ${pet.especie} da raça ${pet.raca}. Estou à procura de uma família que me dê muito amor, carinho e espaço para brincar. Sou muito brincalhão(a), me dou bem com outros animais e adoro passear ao ar livre. Venha me conhecer!',
-                          style: theme.textTheme.bodyLarge?.copyWith(
-                            color: isDark ? AppColors.darkTextPrimary : AppColors.textPrimary,
-                            height: 1.5,
-                          ),
-                        ),
-                        const SizedBox(height: 32),
-
-                        // Caregiver / NGO Info Card
-                        AppCard(
-                          padding: const EdgeInsets.all(16),
-                          child: Row(
-                            children: [
-                              CircleAvatar(
-                                radius: 24,
-                                backgroundColor: AppColors.primary.withAlpha(20),
-                                child: const Icon(Icons.volunteer_activism_rounded, color: AppColors.primary),
-                              ),
-                              const SizedBox(width: 16),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      'ONG Amigo Fiel',
-                                      style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
-                                    ),
-                                    const SizedBox(height: 2),
-                                    Text(
-                                      'Organização Protetora Parceira',
-                                      style: theme.textTheme.bodySmall?.copyWith(
-                                        color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              IconButton(
-                                icon: const Icon(Icons.chat_bubble_outline_rounded, color: AppColors.primary),
-                                onPressed: () {
-                                  ScaffoldMessenger.of(context).showSnackBar(
-                                    const SnackBar(content: Text('Chat em tempo real em desenvolvimento!')),
-                                  );
-                                },
-                              ),
-                            ],
-                          ),
-                        ),
-                        const SizedBox(height: 100), // Spacing for bottom button
-                      ],
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ),
-
-          // Floating Back Button
-          Positioned(
-            top: 48,
-            left: 20,
-            child: CircleAvatar(
-              backgroundColor: Colors.white.withAlpha(200),
-              child: IconButton(
-                icon: const Icon(Icons.arrow_back_ios_new_rounded, color: Colors.black87, size: 20),
-                onPressed: () => context.go('/pets'),
-              ),
-            ),
-          ),
-
-          // Floating Favorite Button
-          Positioned(
-            top: 48,
-            right: 20,
-            child: BlocBuilder<FavoritosCubit, FavoritosState>(
-              builder: (context, state) {
-                final isFav = context.read<FavoritosCubit>().isFavorito(pet);
-                return CircleAvatar(
-                  backgroundColor: Colors.white.withAlpha(200),
-                  child: IconButton(
-                    icon: Icon(
-                      isFav ? Icons.favorite_rounded : Icons.favorite_border_rounded,
-                      color: isFav ? AppColors.primary : Colors.black87,
-                      size: 20,
-                    ),
-                    onPressed: () {
-                      context.read<FavoritosCubit>().toggleFavorito(pet);
-                    },
+                      ),
+                      const SizedBox(height: 32),
+                      AppButton(
+                        text: 'Entendido',
+                        onPressed: () {
+                          Navigator.pop(context);
+                          context.pop(); // Volta para o feed
+                        },
+                      ),
+                    ],
                   ),
                 );
               },
-            ),
-          ),
+            );
+          } else {
+            // Tratamento de duplicata ou erro
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('Você já possui uma solicitação ativa para este pet!'),
+                backgroundColor: Colors.orange,
+              ),
+            );
+          }
+        }
 
-          // Bottom Fixed Action Button
-          Positioned(
-            bottom: 24,
-            left: 24,
-            right: 24,
-            child: AppButton(
-              text: 'Quero Adotar',
-              onPressed: showAdoptionDialog,
-            ),
+        return Scaffold(
+          body: Stack(
+            children: [
+              // Scrollable Content
+              SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    // Hero Image
+                    Hero(
+                      tag: 'pet_img_${currentPet.id}',
+                      child: Image.network(
+                        currentPet.imagemUrl,
+                        height: 380,
+                        fit: BoxFit.cover,
+                        errorBuilder: (context, error, stackTrace) => Container(
+                          height: 380,
+                          color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                          child: const Icon(Icons.broken_image_outlined, size: 80),
+                        ),
+                      ),
+                    ),
+
+                    // Pet Info Container
+                    Transform.translate(
+                      offset: const Offset(0, -20),
+                      child: Container(
+                        decoration: BoxDecoration(
+                          color: isDark ? AppColors.darkBackground : AppColors.background,
+                          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+                        ),
+                        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            // Name & Gender
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      currentPet.nome,
+                                      style: theme.textTheme.headlineMedium?.copyWith(
+                                        fontWeight: FontWeight.bold,
+                                        color: isDark ? Colors.white : Colors.black87,
+                                      ),
+                                    ),
+                                    const SizedBox(height: 4),
+                                    Row(
+                                      children: [
+                                        const Icon(Icons.location_on_outlined, size: 16, color: AppColors.primary),
+                                        const SizedBox(width: 4),
+                                        Text(
+                                          '${currentPet.cidade} - ${currentPet.estado}',
+                                          style: theme.textTheme.bodyMedium?.copyWith(
+                                            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                                Icon(
+                                  currentPet.sexo == 'Macho' ? Icons.male_rounded : Icons.female_rounded,
+                                  size: 32,
+                                  color: currentPet.sexo == 'Macho' ? Colors.blue : Colors.pink,
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 24),
+
+                            // Technical specs
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: [
+                                _buildSpecCard(context, 'Raça', currentPet.raca, isDark),
+                                _buildSpecCard(context, 'Idade',
+                                    '${currentPet.idade} ${currentPet.idade == 1 ? 'ano' : 'anos'}', isDark),
+                                _buildSpecCard(context, 'Porte', currentPet.porte, isDark),
+                              ],
+                            ),
+                            const SizedBox(height: 32),
+
+                            // Vaccine & Castration Badges
+                            Wrap(
+                              spacing: 12,
+                              runSpacing: 8,
+                              children: [
+                                if (currentPet.vacinado)
+                                  _buildBadge(context, 'Vacinado', Icons.check_circle_outline, Colors.green)
+                                else
+                                  _buildBadge(context, 'Vacina Pendente', Icons.info_outline, Colors.orange),
+                                if (currentPet.castrado)
+                                  _buildBadge(context, 'Castrado', Icons.check_circle_outline, Colors.green)
+                                else
+                                  _buildBadge(context, 'Não Castrado', Icons.info_outline, Colors.orange),
+                              ],
+                            ),
+                            const SizedBox(height: 32),
+
+                            // About
+                            Text(
+                              'Sobre mim',
+                              style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              'Olá! Sou o(a) ${currentPet.nome}, um(a) lindo(a) ${currentPet.especie} da raça ${currentPet.raca}. Estou à procura de uma família que me dê muito amor, carinho e espaço para brincar. Sou muito brincalhão(a), me dou bem com outros animais e adoro passear ao ar livre. Venha me conhecer!',
+                              style: theme.textTheme.bodyLarge?.copyWith(
+                                color: isDark ? AppColors.darkTextPrimary : AppColors.textPrimary,
+                                height: 1.5,
+                              ),
+                            ),
+                            const SizedBox(height: 32),
+
+                            // NGO Info Card
+                            AppCard(
+                              padding: const EdgeInsets.all(16),
+                              child: Row(
+                                children: [
+                                  CircleAvatar(
+                                    radius: 24,
+                                    backgroundColor: AppColors.primary.withAlpha(20),
+                                    child: const Icon(Icons.volunteer_activism_rounded, color: AppColors.primary),
+                                  ),
+                                  const SizedBox(width: 16),
+                                  Expanded(
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          'ONG Amigo Fiel',
+                                          style: theme.textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
+                                        ),
+                                        const SizedBox(height: 2),
+                                        Text(
+                                          'Organização Protetora Parceira',
+                                          style: theme.textTheme.bodySmall?.copyWith(
+                                            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  IconButton(
+                                    icon: const Icon(Icons.chat_bubble_outline_rounded, color: AppColors.primary),
+                                    onPressed: () {
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        const SnackBar(content: Text('Chat em tempo real em desenvolvimento!')),
+                                      );
+                                    },
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: 100), // Espaço para o botão fixo
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // Floating Back Button
+              Positioned(
+                top: 48,
+                left: 20,
+                child: CircleAvatar(
+                  backgroundColor: Colors.white.withAlpha(200),
+                  child: IconButton(
+                    icon: const Icon(Icons.arrow_back_ios_new_rounded, color: Colors.black87, size: 20),
+                    onPressed: () => context.pop(),
+                  ),
+                ),
+              ),
+
+              // Floating Favorite Button
+              Positioned(
+                top: 48,
+                right: 20,
+                child: BlocBuilder<FavoritosCubit, FavoritosState>(
+                  builder: (context, state) {
+                    final isFav = context.read<FavoritosCubit>().isFavorito(currentPet);
+                    return CircleAvatar(
+                      backgroundColor: Colors.white.withAlpha(200),
+                      child: IconButton(
+                        icon: Icon(
+                          isFav ? Icons.favorite_rounded : Icons.favorite_border_rounded,
+                          color: isFav ? AppColors.primary : Colors.black87,
+                          size: 20,
+                        ),
+                        onPressed: () {
+                          context.read<FavoritosCubit>().toggleFavorito(currentPet);
+                        },
+                      ),
+                    );
+                  },
+                ),
+              ),
+
+              // Bottom Fixed Action Button (apenas para Adotantes logados)
+              if (!isOng)
+                Positioned(
+                  bottom: 24,
+                  left: 24,
+                  right: 24,
+                  child: AppButton(
+                    text: isLoggedIn ? 'Quero Adotar' : 'Faça Login para Adotar',
+                    onPressed: showAdoptionDialog,
+                  ),
+                ),
+            ],
           ),
-        ],
-      ),
+        );
+      },
     );
   }
 
@@ -404,6 +445,7 @@ class PetDetailPage extends StatelessWidget {
               ),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.center,
             ),
           ],
         ),

--- a/mobile/lib/features/pets/presentation/pages/pets_page.dart
+++ b/mobile/lib/features/pets/presentation/pages/pets_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:mybuddy_app/features/pets/domain/entities/pet.dart';
+import 'package:mybuddy_app/features/pets/presentation/bloc/pets_cubit.dart';
 import 'package:mybuddy_app/features/pets/presentation/bloc/favoritos_cubit.dart';
 import 'package:mybuddy_app/shared/widgets/app_card.dart';
 import 'package:mybuddy_app/shared/widgets/app_input.dart';
@@ -19,109 +20,10 @@ class _PetsPageState extends State<PetsPage> {
   String _selectedCategory = 'Todos';
   String _searchQuery = '';
 
-  static final List<Pet> _allPets = [
-    const Pet(
-      id: '1',
-      nome: 'Pipoca',
-      especie: 'Cachorro',
-      raca: 'Golden Retriever',
-      idade: 2,
-      sexo: 'Macho',
-      porte: 'Grande',
-      cidade: 'Maringá',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1552053831-71594a27632d?q=80&w=400&auto=format&fit=crop',
-      vacinado: true,
-      castrado: true,
-    ),
-    const Pet(
-      id: '2',
-      nome: 'Mia',
-      especie: 'Gato',
-      raca: 'Siamês',
-      idade: 1,
-      sexo: 'Fêmea',
-      porte: 'Pequeno',
-      cidade: 'Sarandi',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?q=80&w=400&auto=format&fit=crop',
-      vacinado: true,
-      castrado: false,
-    ),
-    const Pet(
-      id: '3',
-      nome: 'Bidu',
-      especie: 'Cachorro',
-      raca: 'Poodle',
-      idade: 4,
-      sexo: 'Macho',
-      porte: 'Médio',
-      cidade: 'Maringá',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1583511655857-d19b40a7a54e?q=80&w=400&auto=format&fit=crop',
-      vacinado: false,
-      castrado: true,
-    ),
-    const Pet(
-      id: '4',
-      nome: 'Thor',
-      especie: 'Cachorro',
-      raca: 'Pastor Alemão',
-      idade: 3,
-      sexo: 'Macho',
-      porte: 'Grande',
-      cidade: 'Londrina',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1589941013453-ec89f33b5e95?q=80&w=400&auto=format&fit=crop',
-      vacinado: true,
-      castrado: true,
-    ),
-    const Pet(
-      id: '5',
-      nome: 'Luna',
-      especie: 'Gato',
-      raca: 'Persa',
-      idade: 2,
-      sexo: 'Fêmea',
-      porte: 'Pequeno',
-      cidade: 'Maringá',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1618826411640-d6df44dd3f7a?q=80&w=400&auto=format&fit=crop',
-      vacinado: true,
-      castrado: true,
-    ),
-    const Pet(
-      id: '6',
-      nome: 'Simba',
-      especie: 'Gato',
-      raca: 'Vira-lata',
-      idade: 1,
-      sexo: 'Macho',
-      porte: 'Médio',
-      cidade: 'Paranavaí',
-      estado: 'PR',
-      imagemUrl: 'https://images.unsplash.com/photo-1519052537078-e6302a4968d4?q=80&w=400&auto=format&fit=crop',
-      vacinado: false,
-      castrado: true,
-    ),
-  ];
-
   @override
   void dispose() {
     _searchController.dispose();
     super.dispose();
-  }
-
-  List<Pet> get _filteredPets {
-    return _allPets.where((pet) {
-      final matchesSearch = pet.nome.toLowerCase().contains(_searchQuery.toLowerCase()) ||
-          pet.raca.toLowerCase().contains(_searchQuery.toLowerCase());
-      
-      final matchesCategory = _selectedCategory == 'Todos' ||
-          (physicsCategoryMap[_selectedCategory] == pet.especie);
-
-      return matchesSearch && matchesCategory;
-    }).toList();
   }
 
   static const physicsCategoryMap = {
@@ -260,156 +162,176 @@ class _PetsPageState extends State<PetsPage> {
             ),
             const SizedBox(height: 16),
 
-            // Grid Feed of Pets
+            // Grid Feed of Pets (Reative com PetsCubit e FavoritosCubit)
             Expanded(
-              child: BlocBuilder<FavoritosCubit, FavoritosState>(
-                builder: (context, state) {
-                  final pets = _filteredPets;
+              child: BlocBuilder<PetsCubit, PetsState>(
+                builder: (context, petsState) {
+                  if (petsState is PetsLoading) {
+                    return const Center(child: CircularProgressIndicator());
+                  }
 
-                  if (pets.isEmpty) {
-                    return Center(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        children: [
-                          const Icon(Icons.pets, size: 64, color: Colors.grey),
-                          const SizedBox(height: 16),
-                          Text(
-                            'Nenhum pet encontrado',
-                            style: theme.textTheme.titleMedium?.copyWith(color: Colors.grey),
+                  if (petsState is PetsLoaded) {
+                    return BlocBuilder<FavoritosCubit, FavoritosState>(
+                      builder: (context, favoritosState) {
+                        final pets = petsState.pets.where((pet) {
+                          final matchesSearch = pet.nome.toLowerCase().contains(_searchQuery.toLowerCase()) ||
+                              pet.raca.toLowerCase().contains(_searchQuery.toLowerCase());
+                          
+                          final matchesCategory = _selectedCategory == 'Todos' ||
+                              (physicsCategoryMap[_selectedCategory] == pet.especie);
+
+                          return matchesSearch && matchesCategory;
+                        }).toList();
+
+                        if (pets.isEmpty) {
+                          return Center(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const Icon(Icons.pets, size: 64, color: Colors.grey),
+                                const SizedBox(height: 16),
+                                Text(
+                                  'Nenhum pet encontrado',
+                                  style: theme.textTheme.titleMedium?.copyWith(color: Colors.grey),
+                                ),
+                              ],
+                            ),
+                          );
+                        }
+
+                        return GridView.builder(
+                          padding: const EdgeInsets.all(24),
+                          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: 2,
+                            childAspectRatio: 0.72,
+                            crossAxisSpacing: 16,
+                            mainAxisSpacing: 16,
                           ),
-                        ],
-                      ),
+                          itemCount: pets.length,
+                          itemBuilder: (context, index) {
+                            final pet = pets[index];
+                            final isFav = context.read<FavoritosCubit>().isFavorito(pet);
+
+                            return AppCard(
+                              padding: EdgeInsets.zero,
+                              onTap: () {
+                                context.go('/pets/${pet.id}');
+                              },
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                children: [
+                                  // Pet Image & Favorite Icon
+                                  Expanded(
+                                    child: Stack(
+                                      fit: StackFit.expand,
+                                      children: [
+                                        ClipRRect(
+                                          borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+                                          child: Image.network(
+                                            pet.imagemUrl,
+                                            fit: BoxFit.cover,
+                                            errorBuilder: (context, error, stackTrace) => Container(
+                                              color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
+                                              child: const Icon(Icons.broken_image_outlined, size: 40),
+                                            ),
+                                          ),
+                                        ),
+                                        Positioned(
+                                          top: 8,
+                                          right: 8,
+                                          child: Material(
+                                            color: Colors.white.withAlpha(200),
+                                            shape: const CircleBorder(),
+                                            elevation: 2,
+                                            child: IconButton(
+                                              icon: Icon(
+                                                isFav ? Icons.favorite_rounded : Icons.favorite_border_rounded,
+                                                color: isFav ? AppColors.primary : AppColors.textLight,
+                                                size: 20,
+                                              ),
+                                              onPressed: () {
+                                                context.read<FavoritosCubit>().toggleFavorito(pet);
+                                              },
+                                              constraints: const BoxConstraints(),
+                                              padding: const EdgeInsets.all(6),
+                                            ),
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                  // Pet Information
+                                  Padding(
+                                    padding: const EdgeInsets.all(12),
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Row(
+                                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                          children: [
+                                            Expanded(
+                                              child: Text(
+                                                pet.nome,
+                                                style: theme.textTheme.titleMedium?.copyWith(
+                                                  fontWeight: FontWeight.bold,
+                                                  color: isDark ? Colors.white : Colors.black87,
+                                                ),
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                              ),
+                                            ),
+                                            Icon(
+                                              pet.sexo == 'Macho' ? Icons.male_rounded : Icons.female_rounded,
+                                              size: 18,
+                                              color: pet.sexo == 'Macho' ? Colors.blue : Colors.pink,
+                                            ),
+                                          ],
+                                        ),
+                                        const SizedBox(height: 2),
+                                        Text(
+                                          pet.raca,
+                                          style: theme.textTheme.bodySmall?.copyWith(
+                                            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                            fontWeight: FontWeight.w500,
+                                          ),
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                        const SizedBox(height: 6),
+                                        Row(
+                                          children: [
+                                            const Icon(
+                                              Icons.location_on_outlined,
+                                              size: 14,
+                                              color: AppColors.primary,
+                                            ),
+                                            const SizedBox(width: 2),
+                                            Expanded(
+                                              child: Text(
+                                                '${pet.cidade} - ${pet.estado}',
+                                                style: theme.textTheme.bodySmall?.copyWith(
+                                                  color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
+                                                  fontSize: 11,
+                                                ),
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            );
+                          },
+                        );
+                      },
                     );
                   }
 
-                  return GridView.builder(
-                    padding: const EdgeInsets.all(24),
-                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                      crossAxisCount: 2,
-                      childAspectRatio: 0.72,
-                      crossAxisSpacing: 16,
-                      mainAxisSpacing: 16,
-                    ),
-                    itemCount: pets.length,
-                    itemBuilder: (context, index) {
-                      final pet = pets[index];
-                      final isFav = context.read<FavoritosCubit>().isFavorito(pet);
-
-                      return AppCard(
-                        padding: EdgeInsets.zero,
-                        onTap: () {
-                          context.go('/pets/${pet.id}');
-                        },
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.stretch,
-                          children: [
-                            // Pet Image & Favorite Icon
-                            Expanded(
-                              child: Stack(
-                                fit: StackFit.expand,
-                                children: [
-                                  ClipRRect(
-                                    borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
-                                    child: Image.network(
-                                      pet.imagemUrl,
-                                      fit: BoxFit.cover,
-                                      errorBuilder: (context, error, stackTrace) => Container(
-                                        color: isDark ? Colors.grey.shade800 : Colors.grey.shade200,
-                                        child: const Icon(Icons.broken_image_outlined, size: 40),
-                                      ),
-                                    ),
-                                  ),
-                                  Positioned(
-                                    top: 8,
-                                    right: 8,
-                                    child: Material(
-                                      color: Colors.white.withAlpha(200),
-                                      shape: const CircleBorder(),
-                                      elevation: 2,
-                                      child: IconButton(
-                                        icon: Icon(
-                                          isFav ? Icons.favorite_rounded : Icons.favorite_border_rounded,
-                                          color: isFav ? AppColors.primary : AppColors.textLight,
-                                          size: 20,
-                                        ),
-                                        onPressed: () {
-                                          context.read<FavoritosCubit>().toggleFavorito(pet);
-                                        },
-                                        constraints: const BoxConstraints(),
-                                        padding: const EdgeInsets.all(6),
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ),
-                            ),
-                            // Pet Information
-                            Padding(
-                              padding: const EdgeInsets.all(12),
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Row(
-                                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                    children: [
-                                      Expanded(
-                                        child: Text(
-                                          pet.nome,
-                                          style: theme.textTheme.titleMedium?.copyWith(
-                                            fontWeight: FontWeight.bold,
-                                            color: isDark ? Colors.white : Colors.black87,
-                                          ),
-                                          maxLines: 1,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ),
-                                      Icon(
-                                        pet.sexo == 'Macho' ? Icons.male_rounded : Icons.female_rounded,
-                                        size: 18,
-                                        color: pet.sexo == 'Macho' ? Colors.blue : Colors.pink,
-                                      ),
-                                    ],
-                                  ),
-                                  const SizedBox(height: 2),
-                                  Text(
-                                    pet.raca,
-                                    style: theme.textTheme.bodySmall?.copyWith(
-                                      color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
-                                      fontWeight: FontWeight.w500,
-                                    ),
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                  const SizedBox(height: 6),
-                                  Row(
-                                    children: [
-                                      const Icon(
-                                        Icons.location_on_outlined,
-                                        size: 14,
-                                        color: AppColors.primary,
-                                      ),
-                                      const SizedBox(width: 2),
-                                      Expanded(
-                                        child: Text(
-                                          '${pet.cidade} - ${pet.estado}',
-                                          style: theme.textTheme.bodySmall?.copyWith(
-                                            color: isDark ? AppColors.darkTextSecondary : AppColors.textLight,
-                                            fontSize: 11,
-                                          ),
-                                          maxLines: 1,
-                                          overflow: TextOverflow.ellipsis,
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ],
-                              ),
-                            ),
-                          ],
-                        ),
-                      );
-                    },
-                  );
+                  return const Center(child: Text('Erro ao carregar os animais.'));
                 },
               ),
             ),

--- a/mobile/lib/shared/theme/theme_cubit.dart
+++ b/mobile/lib/shared/theme/theme_cubit.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class ThemeCubit extends Cubit<ThemeMode> {
+  ThemeCubit() : super(ThemeMode.system);
+
+  void updateTheme(ThemeMode mode) {
+    emit(mode);
+  }
+}

--- a/mobile/lib/shared/widgets/main_scaffold.dart
+++ b/mobile/lib/shared/widgets/main_scaffold.dart
@@ -8,9 +8,9 @@ class MainScaffold extends StatelessWidget {
 
   int _currentIndex(BuildContext context) {
     final location = GoRouterState.of(context).matchedLocation;
-    if (location.startsWith('/favoritos')) return 1;
+    if (location.startsWith('/pets')) return 1;
     if (location.startsWith('/marketplace')) return 2;
-    if (location.startsWith('/adocao')) return 3;
+    if (location.startsWith('/eventos')) return 3;
     if (location.startsWith('/perfil')) return 4;
     return 0;
   }
@@ -21,40 +21,41 @@ class MainScaffold extends StatelessWidget {
       body: child,
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _currentIndex(context),
+        type: BottomNavigationBarType.fixed, // Permite 5 itens sem mudar cor de fundo ou distorcer
         onTap: (index) {
           switch (index) {
             case 0:
-              context.go('/pets');
+              context.go('/home');
             case 1:
-              context.go('/favoritos');
+              context.go('/pets');
             case 2:
               context.go('/marketplace');
             case 3:
-              context.go('/adocao');
+              context.go('/eventos');
             case 4:
               context.go('/perfil');
           }
         },
         items: const [
           BottomNavigationBarItem(
+            icon: Icon(Icons.home_outlined),
+            activeIcon: Icon(Icons.home_rounded),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
             icon: Icon(Icons.pets_outlined),
-            activeIcon: Icon(Icons.pets),
+            activeIcon: Icon(Icons.pets_rounded),
             label: 'Pets',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.favorite_outline_rounded),
-            activeIcon: Icon(Icons.favorite_rounded),
-            label: 'Favoritos',
-          ),
-          BottomNavigationBarItem(
             icon: Icon(Icons.storefront_outlined),
-            activeIcon: Icon(Icons.storefront),
+            activeIcon: Icon(Icons.storefront_rounded),
             label: 'Marketplace',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.volunteer_activism_outlined),
-            activeIcon: Icon(Icons.volunteer_activism),
-            label: 'Adoção',
+            icon: Icon(Icons.event_note_outlined),
+            activeIcon: Icon(Icons.event_note_rounded),
+            label: 'Eventos',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.person_outline_rounded),
@@ -66,4 +67,5 @@ class MainScaffold extends StatelessWidget {
     );
   }
 }
+
 


### PR DESCRIPTION
## Task Jira

> Vincule a task relacionada a este PR

- **Card:** [MYB-337](https://mybuddy.atlassian.net/browse/MYB-337)
- **Tipo:** Feature

---

## O que foi feito?

> Descreva de forma objetiva o que este PR implementa ou resolve.

Revisao visual completa e ajustes de UX no aplicativo mobile Flutter. Implementa novas funcionalidades de ponta a ponta: tela Home com dashboard personalizado, fluxo completo de adocao (solicitacao + gestao por ONG), modulo de eventos solidarios, marketplace com CRUD de produtos e tela de pedidos, gestao de pets por ONG (cadastro + listagem "Meus Pets"), painel administrativo com metricas e gerenciamento de contas, e suporte a multiplos perfis de usuario com navegacao adaptada por role (Adotante, ONG, Petshop, Admin). Tambem adiciona ThemeCubit para alternancia de tema (dark/light) e reestrutura a navegacao principal (BottomNavigationBar com 5 abas: Home, Pets, Marketplace, Eventos, Perfil).

---

## Escopo das mudancas

> Marque os modulos afetados por este PR

- [ ] `backend` -- Java / Spring Boot
- [ ] `frontend` -- Angular
- [x] `mobile` -- Flutter
- [ ] `infra` -- Docker / CI / configuracoes

---

## Detalhamento das Implementacoes

### Nova Tela Home (`home_page.dart`) -- [NEW]
- Dashboard com boas-vindas personalizadas (nome do usuario autenticado)
- Banner de destaque com gradiente e CTA "Explorar Pets"
- Menu Rapido em grid (Adotar Pet, Eventos, Marketplace, Perfil) com atalhos de navegacao
- Carrossel horizontal "Destaques de Adocao" com pets em destaque
- Secao "Dica de Cuidado" com conteudo estatico informativo

### Fluxo de Adocao (`features/adocao/`) -- [NEW]
- **AdocaoCubit** (`adocao_cubit.dart`): gerenciamento de estado para solicitacoes de adocao (criar, listar por ONG, atualizar status, vincular pet->ONG)
- **SolicitacoesOngPage** (`solicitacoes_ong_page.dart`): tela para ONGs visualizarem, aprovarem ou recusarem solicitacoes de adocao recebidas; inclui header com contadores (Total, Pendentes, Aprovados)
- **EventosPage** (`eventos_page.dart`): listagem de eventos solidarios/feiras de adocao com cards ricos (imagem, badge, data/hora, local, organizador, descricao) e botao "Confirmar Presenca"

### Marketplace (`features/marketplace/`) -- [NEW + MODIFIED]
- **Entidade Produto** (`produto.dart`): modelo de dominio com id, nome, preco, descricao, imagemUrl, categoria
- **ProductsRepository** + **ProductsRepositoryMock**: camada de dados com mock de produtos (Alimentacao, Acessorios, Higiene, Brinquedos)
- **ProductsCubit** (`products_cubit.dart`): gerenciamento de estado com listagem, cadastro e busca de produtos
- **CadastrarProdutoPage** (`cadastrar_produto_page.dart`): formulario completo para Petshops cadastrarem novos produtos (nome, preco, categoria, descricao, imagem)
- **MeusProdutosPage** (`meus_produtos_page.dart`): listagem dos produtos do Petshop logado
- **PedidosPetshopPage** (`pedidos_petshop_page.dart`): tela de gerenciamento de pedidos recebidos pelo Petshop (mock)
- **MarketplacePage** (modificada): refatoracao completa com grid de produtos, busca, filtro por categoria e carrinho de compras

### Gestao de Pets (`features/pets/`) -- [NEW + MODIFIED]
- **PetsRepository** + **PetsRepositoryMock**: camada de dados com mock de 6 pets e metodos CRUD
- **PetsCubit** (`pets_cubit.dart`): gerenciamento de estado com listagem, cadastro, busca por ONG e exclusao
- **CadastrarPetPage** (`cadastrar_pet_page.dart`): formulario completo para ONGs cadastrarem novos pets (nome, especie, raca, idade, sexo, porte, cidade/UF, foto, vacinacao, castracao)
- **MeusPetsPage** (`meus_pets_page.dart`): listagem dos pets cadastrados pela ONG logada, com FAB para cadastro rapido e pull-to-refresh
- **PetsPage** (modificada): refatoracao visual com filtros e cards de pet redesenhados
- **PetDetailPage** (modificada): redesign completo da tela de detalhes com novo layout e botao "Solicitar Adocao" integrado ao AdocaoCubit

### Painel Administrativo (`admin_dashboard_page.dart`) -- [NEW]
- Grid de metricas gerais (Total Usuarios, ONGs Parceiras, Petshops, Adocoes Feitas) com icones coloridos
- Gerenciamento de contas de usuarios com toggle ativar/desativar por Switch

### Perfil (`perfil_page.dart`) -- [MODIFIED]
- Adaptacao dinamica do menu por role (ex: ONG ve "Meus Pets" e "Solicitacoes", Petshop ve "Meus Produtos" e "Pedidos", Admin ve "Painel Administrativo")
- Secao de alternancia de tema (Light, Dark, Sistema) integrada ao ThemeCubit

### Autenticacao (`auth/`) -- [MODIFIED]
- **AuthRepositoryMock**: 4 perfis de login mock com navegacao adaptada:
  - `user@mybuddy.com` / `Senha123` -> Adotante
  - `ong@mybuddy.com` / `Senha123` -> ONG
  - `petshop@mybuddy.com` / `Senha123` -> Petshop
  - `admin@mybuddy.com` / `Senha123` -> Admin
- **User entity**: adicao do campo `roles` para controle de acesso por perfil

### Tema e Navegacao -- [NEW + MODIFIED]
- **ThemeCubit** (`theme_cubit.dart`): controle de tema (light/dark/system) via BLoC
- **MainScaffold** (modificado): BottomNavigationBar reestruturado com 5 abas (Home -> Pets -> Marketplace -> Eventos -> Perfil), `BottomNavigationBarType.fixed`
- **AppRouter** (modificado): novas rotas para `/home`, `/eventos`, `/solicitacoes-ong`, `/cadastrar-pet`, `/meus-pets`, `/cadastrar-produto`, `/meus-produtos`, `/pedidos-petshop`, `/admin-dashboard`
- **InjectionContainer** (modificado): registro de novos Cubits e repositorios (PetsCubit, ProductsCubit, AdocaoCubit, ThemeCubit)
- **App** (modificado): integracao do ThemeCubit no MaterialApp para aplicar o tema dinamico

---

## Checklist de Testes

> Confirme que os cenarios abaixo foram validados antes de abrir o PR

- [x] Testei localmente e o comportamento esta conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Nao ha erros ou warnings novos no console
- [x] Validei em mais de um ambiente (se aplicavel)
- [ ] Testes automatizados foram criados ou atualizados (se aplicavel)

---

## Checklist de Code Review

> Para o **autor** preencher antes de solicitar revisao

- [x] O codigo segue os padroes e convencoes do projeto
- [x] Nao ha codigo comentado ou `TODO` esquecido sem justificativa
- [x] Variaveis, metodos e classes tem nomes claros e descritivos
- [x] Nao ha logica duplicada que poderia ser extraida
- [x] Dados sensiveis nao estao expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e sao reversiveis

---

## Notas para o Revisor

> Algum ponto de atencao, decisao tecnica ou contexto que o revisor deve saber?

- **Dados 100% mock**: todos os repositorios utilizam dados em memoria (mock). Nao ha integracao com backend real neste PR. A arquitetura (Repository Pattern + BLoC/Cubit) esta pronta para substituicao por implementacoes reais quando os endpoints estiverem disponiveis.
- **Navegacao adaptada por role**: o perfil do usuario (roles do JWT) define quais itens aparecem no menu da PerfilPage. O controle e feito via `AuthRepositoryMock` com 4 perfis distintos.
- **ThemeCubit**: o estado do tema e mantido apenas em memoria; ao fechar o app o tema volta ao padrao `ThemeMode.system`. Persistencia pode ser adicionada futuramente com `shared_preferences`.
- **AdocaoCubit <-> PetsCubit**: ao cadastrar um novo pet, o `CadastrarPetPage` registra a associacao `petId -> ongId` no `AdocaoCubit` para que as solicitacoes de adocao funcionem corretamente.
- **MainScaffold**: a BottomNavigationBar foi trocada de 5 abas (Pets, Favoritos, Marketplace, Adocao, Perfil) para (Home, Pets, Marketplace, Eventos, Perfil). A aba "Favoritos" e "Adocao" foram removidas da barra principal mas continuam acessiveis por navegacao interna.

---

## Como testar

> Passo a passo para o revisor reproduzir e validar as mudancas

```
1. Faca checkout da branch: git checkout MY-337-Revisao-visual-e-ajustes-de-UX
2. Execute: cd mobile && flutter pub get && flutter run -d chrome (ou dispositivo/emulador)
3. Na tela de Login, teste os 4 perfis:
   - user@mybuddy.com / Senha123 -> Perfil Adotante (Home com dashboard, pode solicitar adocao)
   - ong@mybuddy.com / Senha123 -> Perfil ONG (Perfil mostra "Meus Pets", "Cadastrar Pet", "Solicitacoes de Adocao")
   - petshop@mybuddy.com / Senha123 -> Perfil Petshop (Perfil mostra "Meus Produtos", "Cadastrar Produto", "Pedidos")
   - admin@mybuddy.com / Senha123 -> Perfil Admin (Perfil mostra "Painel Administrativo")
4. Na aba Home: verifique banner, menu rapido, destaques de adocao e dica de cuidado
5. Na aba Pets: verifique filtros, cards de pet, e toque em um pet para ver os detalhes + botao "Solicitar Adocao"
6. Na aba Marketplace: verifique grid de produtos, busca, filtro por categoria
7. Na aba Eventos: verifique lista de eventos e botao "Confirmar Presenca"
8. Na aba Perfil: verifique menu adaptado por role e alternancia de tema (Light/Dark/System)
9. (ONG) Acesse "Meus Pets" e "Cadastrar Pet" para testar o fluxo de gestao de pets
10. (ONG) Acesse "Solicitacoes de Adocao" para testar aprovacao/recusa de solicitacoes
```
