### PR TITLE
My 32 3.3 marketplace backend crud

### DIFF
--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/MongoIdEventListener.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/MongoIdEventListener.java
@@ -2,6 +2,7 @@ package com.Mybuddy.Myb.Config;
 
 import com.Mybuddy.Myb.Model.Identifiable;
 import com.Mybuddy.Myb.Service.SequenceGeneratorService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.BeforeConvertEvent;
 import org.springframework.stereotype.Component;
@@ -14,13 +15,10 @@ import java.lang.reflect.Field;
  * caso o campo 'id' (do tipo Long) esteja nulo.
  */
 @Component
+@RequiredArgsConstructor
 public class MongoIdEventListener extends AbstractMongoEventListener<Object> {
 
     private final SequenceGeneratorService sequenceGenerator;
-
-    public MongoIdEventListener(SequenceGeneratorService sequenceGenerator) {
-        this.sequenceGenerator = sequenceGenerator;
-    }
 
     @Override
     public void onBeforeConvert(BeforeConvertEvent<Object> event) {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
@@ -45,6 +45,9 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/api/payments/preference/**").permitAll()
                         .requestMatchers("/api/payments/webhook").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/produtos/**").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/categorias/**").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/petshop/**").permitAll()
                         .anyRequest().authenticated())
                 .headers(headers -> headers
                         .frameOptions(frame -> frame.sameOrigin()))

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
@@ -16,19 +16,17 @@ import static org.springframework.security.config.Customizer.withDefaults;
 import java.util.List;
 
 import com.Mybuddy.Myb.Security.JwtAuthConverter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
         private final JwtAuthConverter jwtAuthConverter;
-
-        public SecurityConfig(JwtAuthConverter jwtAuthConverter) {
-                this.jwtAuthConverter = jwtAuthConverter;
-        }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AdminController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AdminController.java
@@ -4,6 +4,7 @@ import com.Mybuddy.Myb.Model.Organizacao;
 import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Repository.mongo.OrganizacaoRepository;
 import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,15 +13,11 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/admin")
+@RequiredArgsConstructor
 public class AdminController {
 
     private final OrganizacaoRepository organizacaoRepository;
     private final UsuarioRepository usuarioRepository;
-
-    public AdminController(OrganizacaoRepository organizacaoRepository, UsuarioRepository usuarioRepository) {
-        this.organizacaoRepository = organizacaoRepository;
-        this.usuarioRepository = usuarioRepository;
-    }
 
     @GetMapping("/ongs")
     public ResponseEntity<List<Organizacao>> getOngs() {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AuthController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AuthController.java
@@ -5,6 +5,7 @@ import com.Mybuddy.Myb.Payload.Response.MessageResponse;
 import com.Mybuddy.Myb.Service.AuthService;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -12,23 +13,15 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
     private final KeycloakUserSyncService keycloakUserSyncService;
 
-    public AuthController(AuthService authService, KeycloakUserSyncService keycloakUserSyncService) {
-        this.authService = authService;
-        this.keycloakUserSyncService = keycloakUserSyncService;
-    }
-
     @PostMapping("/cadastro")
     public ResponseEntity<?> registerUser(@Valid @RequestBody SignupRequest signUpRequest) {
-        try {
-            authService.registerUser(signUpRequest);
-            return ResponseEntity.ok(new MessageResponse("Usuário registrado com sucesso!"));
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(new MessageResponse(e.getMessage()));
-        }
+        authService.registerUser(signUpRequest);
+        return ResponseEntity.ok(new MessageResponse("Usuário registrado com sucesso!"));
     }
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AvaliacaoProdutoController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/AvaliacaoProdutoController.java
@@ -1,0 +1,46 @@
+package com.Mybuddy.Myb.Controller;
+
+import com.Mybuddy.Myb.DTO.AvaliacaoProdutoRequestDTO;
+import com.Mybuddy.Myb.DTO.AvaliacaoProdutoResponseDTO;
+import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Service.AvaliacaoProdutoService;
+import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/produtos/{produtoId}/avaliacoes")
+@RequiredArgsConstructor
+@Slf4j
+public class AvaliacaoProdutoController {
+
+    private final AvaliacaoProdutoService avaliacaoProdutoService;
+    private final KeycloakUserSyncService keycloakUserSyncService;
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<AvaliacaoProdutoResponseDTO> criar(
+            @PathVariable Long produtoId,
+            @Valid @RequestBody AvaliacaoProdutoRequestDTO request,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição para avaliar o produto ID: {}", produtoId);
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.status(HttpStatus.CREATED).body(avaliacaoProdutoService.criar(produtoId, request, usuario));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<AvaliacaoProdutoResponseDTO>> listarPorProduto(
+            @PathVariable Long produtoId) {
+        log.info("Buscando avaliações para o produto ID: {}", produtoId);
+        return ResponseEntity.ok(avaliacaoProdutoService.listarPorProduto(produtoId));
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/CampanhaDoacaoController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/CampanhaDoacaoController.java
@@ -1,5 +1,6 @@
 package com.Mybuddy.Myb.Controller;
 
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
 import com.Mybuddy.Myb.Model.CampanhaDoacao;
 import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Security.ERole;
@@ -81,7 +82,7 @@ public class CampanhaDoacaoController {
                 throw new IllegalStateException("Usuário do tipo ONG não possui organização associada.");
             }
             CampanhaDoacao existente = service.buscarPorId(id)
-                    .orElseThrow(() -> new RuntimeException("Campanha não encontrada: " + id));
+                    .orElseThrow(() -> new ResourceNotFoundException("Campanha não encontrada: " + id));
             
             if (!usuario.getOrganizacao().getId().equals(existente.getOrganizacaoId())) {
                 throw new org.springframework.security.authorization.AuthorizationDeniedException(

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/CategoriaController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/CategoriaController.java
@@ -1,0 +1,67 @@
+package com.Mybuddy.Myb.Controller;
+
+import com.Mybuddy.Myb.DTO.CategoriaRequestDTO;
+import com.Mybuddy.Myb.DTO.CategoriaResponseDTO;
+import com.Mybuddy.Myb.DTO.SubCategoriaRequestDTO;
+import com.Mybuddy.Myb.DTO.SubCategoriaResponseDTO;
+import com.Mybuddy.Myb.Service.CategoriaService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/categorias")
+@RequiredArgsConstructor
+@Slf4j
+public class CategoriaController {
+
+    private final CategoriaService categoriaService;
+
+    @GetMapping
+    public ResponseEntity<List<CategoriaResponseDTO>> listarTodas() {
+        log.info("Buscando todas as categorias e subcategorias.");
+        return ResponseEntity.ok(categoriaService.listarTodas());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<CategoriaResponseDTO> buscarPorId(@PathVariable Long id) {
+        log.info("Buscando categoria por ID: {}", id);
+        return ResponseEntity.ok(categoriaService.buscarPorId(id));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<CategoriaResponseDTO> criar(@Valid @RequestBody CategoriaRequestDTO request) {
+        log.info("Requisição para criar categoria recebida: {}", request.getNome());
+        return ResponseEntity.status(HttpStatus.CREATED).body(categoriaService.criar(request));
+    }
+
+    @PostMapping("/subcategorias")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<SubCategoriaResponseDTO> criarSubcategoria(@Valid @RequestBody SubCategoriaRequestDTO request) {
+        log.info("Requisição para criar subcategoria recebida: {}", request.getNome());
+        return ResponseEntity.status(HttpStatus.CREATED).body(categoriaService.criarSubcategoria(request));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+        log.info("Requisição para deletar categoria ID: {}", id);
+        categoriaService.deletar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/subcategorias/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deletarSubcategoria(@PathVariable Long id) {
+        log.info("Requisição para deletar subcategoria ID: {}", id);
+        categoriaService.deletarSubcategoria(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/InteresseAdocaoController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/InteresseAdocaoController.java
@@ -9,6 +9,7 @@ import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,17 +21,13 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api")
+@RequiredArgsConstructor
 public class InteresseAdocaoController {
 
     private static final Logger logger = LoggerFactory.getLogger(InteresseAdocaoController.class);
 
     private final InteresseAdocaoService service;
     private final KeycloakUserSyncService keycloakUserSyncService;
-
-    public InteresseAdocaoController(InteresseAdocaoService service, KeycloakUserSyncService keycloakUserSyncService) {
-        this.service = service;
-        this.keycloakUserSyncService = keycloakUserSyncService;
-    }
 
     @PostMapping("/interesses")
     @PreAuthorize("isAuthenticated()")
@@ -39,7 +36,7 @@ public class InteresseAdocaoController {
             @AuthenticationPrincipal Jwt jwt) {
         Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
         logger.debug("manifestarInteresse: Usuario ID: {}, Email: {}", usuario.getId(), usuario.getEmail());
-        var resp = service.manifestarInteresse(usuario.getId(), req.petId(), req.mensagem());
+        var resp = service.manifestarInteresse(usuario.getId(), req);
         return ResponseEntity.status(HttpStatus.CREATED).body(resp);
     }
 

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/OngController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/OngController.java
@@ -9,6 +9,7 @@ import com.Mybuddy.Myb.Repository.mongo.EventoOngRepository;
 import com.Mybuddy.Myb.Repository.mongo.InteresseAdocaoRepository;
 import com.Mybuddy.Myb.Repository.mongo.PetRepository;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,22 +20,13 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/ong")
+@RequiredArgsConstructor
 public class OngController {
 
     private final InteresseAdocaoRepository interesseAdocaoRepository;
     private final EventoOngRepository eventoOngRepository;
     private final PetRepository petRepository;
     private final KeycloakUserSyncService keycloakUserSyncService;
-
-    public OngController(InteresseAdocaoRepository interesseAdocaoRepository, 
-                         EventoOngRepository eventoOngRepository, 
-                         PetRepository petRepository,
-                         KeycloakUserSyncService keycloakUserSyncService) {
-        this.interesseAdocaoRepository = interesseAdocaoRepository;
-        this.eventoOngRepository = eventoOngRepository;
-        this.petRepository = petRepository;
-        this.keycloakUserSyncService = keycloakUserSyncService;
-    }
 
     @GetMapping("/solicitacoes")
     @PreAuthorize("hasRole('ONG') or hasRole('ADMIN')")

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/OrganizacaoController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/OrganizacaoController.java
@@ -8,6 +8,7 @@ import com.Mybuddy.Myb.Service.OrganizacaoService;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,17 +21,13 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/organizacoes")
+@RequiredArgsConstructor
 public class OrganizacaoController {
 
     private static final Logger log = LoggerFactory.getLogger(OrganizacaoController.class);
 
     private final OrganizacaoService organizacaoService;
     private final KeycloakUserSyncService keycloakUserSyncService;
-
-    public OrganizacaoController(OrganizacaoService organizacaoService, KeycloakUserSyncService keycloakUserSyncService) {
-        this.organizacaoService = organizacaoService;
-        this.keycloakUserSyncService = keycloakUserSyncService;
-    }
 
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PedidoController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PedidoController.java
@@ -1,0 +1,90 @@
+package com.Mybuddy.Myb.Controller;
+
+import com.Mybuddy.Myb.DTO.PedidoRequestDTO;
+import com.Mybuddy.Myb.DTO.PedidoResponseDTO;
+import com.Mybuddy.Myb.Model.StatusPedido;
+import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
+import com.Mybuddy.Myb.Service.PedidoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/pedidos")
+@RequiredArgsConstructor
+@Slf4j
+public class PedidoController {
+
+    private final PedidoService pedidoService;
+    private final KeycloakUserSyncService keycloakUserSyncService;
+
+    @PostMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<PedidoResponseDTO> criar(
+            @Valid @RequestBody PedidoRequestDTO request,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição para realizar compra no marketplace recebida.");
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        PedidoResponseDTO criado = pedidoService.criar(request, usuario);
+        return ResponseEntity.created(URI.create("/api/pedidos/" + criado.getId())).body(criado);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<PedidoResponseDTO> buscarPorId(
+            @PathVariable Long id,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Buscando detalhes do pedido ID: {}", id);
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(pedidoService.buscarPorIdDTO(id, usuario));
+    }
+
+    @GetMapping("/meus")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<List<PedidoResponseDTO>> listarMeusPedidos(
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Listando pedidos do cliente logado.");
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(pedidoService.listarPedidosCliente(usuario));
+    }
+
+    @GetMapping("/petshop")
+    @PreAuthorize("hasRole('PETSHOP') or hasRole('ADMIN')")
+    public ResponseEntity<List<PedidoResponseDTO>> listarPedidosPetshop(
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Listando pedidos recebidos pelo petshop logado.");
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(pedidoService.listarPedidosPetshop(usuario));
+    }
+
+    @PutMapping("/{id}/status")
+    @PreAuthorize("hasRole('PETSHOP') or hasRole('ADMIN')")
+    public ResponseEntity<PedidoResponseDTO> atualizarStatus(
+            @PathVariable Long id,
+            @RequestParam StatusPedido status,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição para alterar status do pedido ID {} para {}", id, status);
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(pedidoService.atualizarStatus(id, status, usuario));
+    }
+
+    @PostMapping("/{id}/cancelar")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<PedidoResponseDTO> cancelar(
+            @PathVariable Long id,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição de cancelamento para o pedido ID: {}", id);
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(pedidoService.cancelar(id, usuario));
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PetController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PetController.java
@@ -11,6 +11,7 @@ import com.Mybuddy.Myb.Service.PetService;
 import jakarta.validation.Valid;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -28,6 +29,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/pets")
+@RequiredArgsConstructor
 public class PetController {
 
     private static final Logger log = LoggerFactory.getLogger(PetController.class);
@@ -35,12 +37,6 @@ public class PetController {
     private final PetService petService;
     private final FotoPetService fotoPetService;
     private final KeycloakUserSyncService keycloakUserSyncService;
-
-    public PetController(PetService petService, FotoPetService fotoPetService, KeycloakUserSyncService keycloakUserSyncService) {
-        this.petService = petService;
-        this.fotoPetService = fotoPetService;
-        this.keycloakUserSyncService = keycloakUserSyncService;
-    }
 
     @PostMapping
     @PreAuthorize("hasRole('ONG') or hasRole('ADMIN')")

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PetshopController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PetshopController.java
@@ -1,5 +1,7 @@
 package com.Mybuddy.Myb.Controller;
 
+import com.Mybuddy.Myb.DTO.PetshopRequestDTO;
+import com.Mybuddy.Myb.DTO.PetshopResponseDTO;
 import com.Mybuddy.Myb.Model.Chat;
 import com.Mybuddy.Myb.Model.Pedido;
 import com.Mybuddy.Myb.Model.Produto;
@@ -9,32 +11,85 @@ import com.Mybuddy.Myb.Repository.mongo.ChatRepository;
 import com.Mybuddy.Myb.Repository.jpa.PedidoRepository;
 import com.Mybuddy.Myb.Repository.jpa.ProdutoRepository;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
+import com.Mybuddy.Myb.Service.PetshopService;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.web.bind.annotation.*;
 
+import java.net.URI;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/petshop")
+@Slf4j
 public class PetshopController {
 
+    private final PetshopService petshopService;
     private final ProdutoRepository produtoRepository;
     private final PedidoRepository pedidoRepository;
     private final ChatRepository chatRepository;
     private final KeycloakUserSyncService keycloakUserSyncService;
 
-    public PetshopController(ProdutoRepository produtoRepository, 
+    public PetshopController(PetshopService petshopService,
+                             ProdutoRepository produtoRepository, 
                              PedidoRepository pedidoRepository, 
                              ChatRepository chatRepository,
                              KeycloakUserSyncService keycloakUserSyncService) {
+        this.petshopService = petshopService;
         this.produtoRepository = produtoRepository;
         this.pedidoRepository = pedidoRepository;
         this.chatRepository = chatRepository;
         this.keycloakUserSyncService = keycloakUserSyncService;
     }
+
+    @PostMapping
+    @PreAuthorize("hasRole('PETSHOP') or hasRole('ADMIN')")
+    public ResponseEntity<PetshopResponseDTO> criar(
+            @Valid @RequestBody PetshopRequestDTO request,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição para criar perfil de petshop: {}", request.getNomeFantasia());
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        PetshopResponseDTO criado = petshopService.criar(request, usuario);
+        return ResponseEntity.created(URI.create("/api/petshop/" + criado.getId())).body(criado);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PetshopResponseDTO> buscarPorId(@PathVariable Long id) {
+        log.info("Buscando petshop por ID: {}", id);
+        return ResponseEntity.ok(petshopService.buscarPorId(id));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<PetshopResponseDTO>> listarTodos() {
+        log.info("Buscando lista de todos os petshops.");
+        return ResponseEntity.ok(petshopService.listarTodos());
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('PETSHOP') or hasRole('ADMIN')")
+    public ResponseEntity<PetshopResponseDTO> atualizar(
+            @PathVariable Long id,
+            @Valid @RequestBody PetshopRequestDTO request,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição para atualizar petshop ID: {}", id);
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(petshopService.atualizar(id, request, usuario));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+        log.info("Requisição para deletar petshop ID: {}", id);
+        petshopService.deletar(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── LEGACY ENDPOINTS (Compatibilidade com Front) ──────────────────────────
 
     @GetMapping("/produtos")
     @PreAuthorize("isAuthenticated()")

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PetshopController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/PetshopController.java
@@ -13,6 +13,7 @@ import com.Mybuddy.Myb.Repository.jpa.ProdutoRepository;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
 import com.Mybuddy.Myb.Service.PetshopService;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +27,7 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/petshop")
+@RequiredArgsConstructor
 @Slf4j
 public class PetshopController {
 
@@ -34,18 +36,6 @@ public class PetshopController {
     private final PedidoRepository pedidoRepository;
     private final ChatRepository chatRepository;
     private final KeycloakUserSyncService keycloakUserSyncService;
-
-    public PetshopController(PetshopService petshopService,
-                             ProdutoRepository produtoRepository, 
-                             PedidoRepository pedidoRepository, 
-                             ChatRepository chatRepository,
-                             KeycloakUserSyncService keycloakUserSyncService) {
-        this.petshopService = petshopService;
-        this.produtoRepository = produtoRepository;
-        this.pedidoRepository = pedidoRepository;
-        this.chatRepository = chatRepository;
-        this.keycloakUserSyncService = keycloakUserSyncService;
-    }
 
     @PostMapping
     @PreAuthorize("hasRole('PETSHOP') or hasRole('ADMIN')")

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/ProdutoController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/ProdutoController.java
@@ -1,0 +1,96 @@
+package com.Mybuddy.Myb.Controller;
+
+import com.Mybuddy.Myb.DTO.ProdutoRequestDTO;
+import com.Mybuddy.Myb.DTO.ProdutoResponseDTO;
+import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
+import com.Mybuddy.Myb.Service.ProdutoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.*;
+
+import java.math.BigDecimal;
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/produtos")
+@RequiredArgsConstructor
+@Slf4j
+public class ProdutoController {
+
+    private final ProdutoService produtoService;
+    private final KeycloakUserSyncService keycloakUserSyncService;
+
+    @GetMapping
+    public ResponseEntity<Page<ProdutoResponseDTO>> buscarComFiltros(
+            @RequestParam(required = false) String busca,
+            @RequestParam(required = false) Long categoriaId,
+            @RequestParam(required = false) Long subCategoriaId,
+            @RequestParam(required = false) Long petshopId,
+            @RequestParam(required = false) BigDecimal precoMin,
+            @RequestParam(required = false) BigDecimal precoMax,
+            @PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+
+        log.info("Buscando produtos com filtros: busca={}, categoriaId={}, subCategoriaId={}, petshopId={}, precoMin={}, precoMax={}",
+                busca, categoriaId, subCategoriaId, petshopId, precoMin, precoMax);
+
+        return ResponseEntity.ok(produtoService.buscarComFiltros(busca, categoriaId, subCategoriaId, petshopId, precoMin, precoMax, pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ProdutoResponseDTO> buscarPorId(@PathVariable Long id) {
+        log.info("Buscando produto por ID: {}", id);
+        return ResponseEntity.ok(produtoService.buscarPorIdDTO(id));
+    }
+
+    @GetMapping("/petshop/{petshopId}")
+    public ResponseEntity<Page<ProdutoResponseDTO>> buscarPorPetshop(
+            @PathVariable Long petshopId,
+            @PageableDefault(size = 12, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        log.info("Buscando produtos para o Petshop ID: {}", petshopId);
+        return ResponseEntity.ok(produtoService.buscarPorPetshop(petshopId, pageable));
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('PETSHOP') or hasRole('ADMIN')")
+    public ResponseEntity<ProdutoResponseDTO> criar(
+            @Valid @RequestBody ProdutoRequestDTO request,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição para cadastrar produto recebida: {}", request.getNome());
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        ProdutoResponseDTO criado = produtoService.criar(request, usuario);
+        return ResponseEntity.created(URI.create("/api/produtos/" + criado.getId())).body(criado);
+    }
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('PETSHOP') or hasRole('ADMIN')")
+    public ResponseEntity<ProdutoResponseDTO> atualizar(
+            @PathVariable Long id,
+            @Valid @RequestBody ProdutoRequestDTO request,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição para atualizar produto ID: {}", id);
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        return ResponseEntity.ok(produtoService.atualizar(id, request, usuario));
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('PETSHOP') or hasRole('ADMIN')")
+    public ResponseEntity<Void> deletar(
+            @PathVariable Long id,
+            @AuthenticationPrincipal Jwt jwt) {
+        log.info("Requisição para deletar produto ID: {}", id);
+        Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
+        produtoService.deletar(id, usuario);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/UploadsController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/UploadsController.java
@@ -4,6 +4,7 @@ import com.Mybuddy.Myb.Model.Arquivo;
 import com.Mybuddy.Myb.Repository.mongo.ArquivoRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -12,15 +13,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class UploadsController {
 
     private static final Logger log = LoggerFactory.getLogger(UploadsController.class);
 
     private final ArquivoRepository arquivoRepository;
-
-    public UploadsController(ArquivoRepository arquivoRepository) {
-        this.arquivoRepository = arquivoRepository;
-    }
 
     @GetMapping("/uploads/{filename:.+}")
     public ResponseEntity<byte[]> serveFile(@PathVariable String filename) {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/UsuarioController.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Controller/UsuarioController.java
@@ -4,6 +4,7 @@ import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Service.FotoPetService;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
 import com.Mybuddy.Myb.Service.UsuarioService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -16,26 +17,17 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/api/usuarios")
+@RequiredArgsConstructor
 public class UsuarioController {
 
     private final UsuarioService usuarioService;
     private final KeycloakUserSyncService keycloakUserSyncService;
     private final FotoPetService fotoPetService;
 
-    public UsuarioController(UsuarioService usuarioService, KeycloakUserSyncService keycloakUserSyncService, FotoPetService fotoPetService) {
-        this.usuarioService = usuarioService;
-        this.keycloakUserSyncService = keycloakUserSyncService;
-        this.fotoPetService = fotoPetService;
-    }
-
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Usuario> criarUsuario(@RequestBody Usuario usuario) {
-        try {
-            return new ResponseEntity<>(usuarioService.criarUsuario(usuario), HttpStatus.CREATED);
-        } catch (IllegalStateException e) {
-            return new ResponseEntity<>(null, HttpStatus.CONFLICT);
-        }
+        return new ResponseEntity<>(usuarioService.criarUsuario(usuario), HttpStatus.CREATED);
     }
 
     @GetMapping
@@ -92,21 +84,13 @@ public class UsuarioController {
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Usuario> atualizarUsuario(@PathVariable Long id, @RequestBody Usuario dadosUsuario) {
-        try {
-            return ResponseEntity.ok(usuarioService.atualizarUsuario(id, dadosUsuario));
-        } catch (IllegalStateException e) {
-            return ResponseEntity.notFound().build();
-        }
+        return ResponseEntity.ok(usuarioService.atualizarUsuario(id, dadosUsuario));
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deletarUsuario(@PathVariable Long id) {
-        try {
-            usuarioService.deletarUsuario(id);
-            return ResponseEntity.noContent().build();
-        } catch (IllegalStateException e) {
-            return ResponseEntity.notFound().build();
-        }
+        usuarioService.deletarUsuario(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/AvaliacaoProdutoRequestDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/AvaliacaoProdutoRequestDTO.java
@@ -1,0 +1,23 @@
+package com.Mybuddy.Myb.DTO;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AvaliacaoProdutoRequestDTO {
+
+    @NotNull(message = "A nota é obrigatória.")
+    @Min(value = 1, message = "A nota mínima é 1.")
+    @Max(value = 5, message = "A nota máxima é 5.")
+    private Integer nota;
+
+    @Size(max = 1000, message = "O comentário deve ter no máximo 1000 caracteres.")
+    private String comentario;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/AvaliacaoProdutoResponseDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/AvaliacaoProdutoResponseDTO.java
@@ -1,0 +1,21 @@
+package com.Mybuddy.Myb.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AvaliacaoProdutoResponseDTO {
+    private Long id;
+    private Long produtoId;
+    private Long clienteId;
+    private String clienteNome;
+    private Integer nota;
+    private String comentario;
+    private LocalDateTime dataCriacao;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/CategoriaRequestDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/CategoriaRequestDTO.java
@@ -1,0 +1,17 @@
+package com.Mybuddy.Myb.DTO;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoriaRequestDTO {
+
+    @NotBlank(message = "O nome da categoria é obrigatório.")
+    @Size(max = 100, message = "O nome da categoria deve ter no máximo 100 caracteres.")
+    private String nome;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/CategoriaResponseDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/CategoriaResponseDTO.java
@@ -1,0 +1,15 @@
+package com.Mybuddy.Myb.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CategoriaResponseDTO {
+    private Long id;
+    private String nome;
+    private List<SubCategoriaResponseDTO> subcategorias;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/EnderecoEntregaDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/EnderecoEntregaDTO.java
@@ -1,0 +1,42 @@
+package com.Mybuddy.Myb.DTO;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EnderecoEntregaDTO {
+
+    @NotBlank(message = "O CEP é obrigatório.")
+    @Size(max = 20, message = "O CEP deve ter no máximo 20 caracteres.")
+    private String cep;
+
+    @NotBlank(message = "O logradouro é obrigatório.")
+    @Size(max = 255, message = "O logradouro deve ter no máximo 255 caracteres.")
+    private String logradouro;
+
+    @NotBlank(message = "O número é obrigatório.")
+    @Size(max = 50, message = "O número deve ter no máximo 50 caracteres.")
+    private String numero;
+
+    @Size(max = 255, message = "O complemento deve ter no máximo 255 caracteres.")
+    private String complemento;
+
+    @NotBlank(message = "O bairro é obrigatório.")
+    @Size(max = 100, message = "O bairro deve ter no máximo 100 caracteres.")
+    private String bairro;
+
+    @NotBlank(message = "A cidade é obrigatória.")
+    @Size(max = 100, message = "A cidade deve ter no máximo 100 caracteres.")
+    private String cidade;
+
+    @NotBlank(message = "O estado é obrigatório.")
+    @Size(max = 50, message = "O estado deve ter no máximo 50 caracteres.")
+    private String estado;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/InteresseAdocaoMapper.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/InteresseAdocaoMapper.java
@@ -20,7 +20,10 @@ public final class InteresseAdocaoMapper {
                 i.getStatus(),
                 i.getMensagem(),
                 i.getCriadoEm(),
-                i.getAtualizadoEm()
+                i.getAtualizadoEm(),
+                i.getCpfAdotante(),
+                i.getIdadeAdotante(),
+                i.getMotivoAdocao()
         );
     }
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/InteresseResponse.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/InteresseResponse.java
@@ -10,5 +10,8 @@ public record InteresseResponse(
         StatusInteresse status,
         String mensagem,
         LocalDateTime criadoEm,
-        LocalDateTime atualizadoEm
+        LocalDateTime atualizadoEm,
+        String cpfAdotante,
+        Integer idadeAdotante,
+        String motivoAdocao
 ) {}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/ItemPedidoRequestDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/ItemPedidoRequestDTO.java
@@ -1,0 +1,20 @@
+package com.Mybuddy.Myb.DTO;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemPedidoRequestDTO {
+
+    @NotNull(message = "O ID do produto é obrigatório.")
+    private Long produtoId;
+
+    @NotNull(message = "A quantidade do produto é obrigatória.")
+    @Min(value = 1, message = "A quantidade mínima do item deve ser 1.")
+    private Integer quantidade;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/ItemPedidoResponseDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/ItemPedidoResponseDTO.java
@@ -1,0 +1,19 @@
+package com.Mybuddy.Myb.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ItemPedidoResponseDTO {
+    private Long produtoId;
+    private String produtoNome;
+    private Integer quantidade;
+    private BigDecimal precoUnitario;
+    private BigDecimal subtotal;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PedidoRequestDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PedidoRequestDTO.java
@@ -1,0 +1,26 @@
+package com.Mybuddy.Myb.DTO;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PedidoRequestDTO {
+
+    @NotNull(message = "O ID do petshop é obrigatório.")
+    private Long petshopId;
+
+    @NotNull(message = "O endereço de entrega é obrigatório.")
+    @Valid
+    private EnderecoEntregaDTO enderecoEntrega;
+
+    @NotEmpty(message = "O pedido deve conter pelo menos um item.")
+    @Valid
+    private List<ItemPedidoRequestDTO> itens;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PedidoResponseDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PedidoResponseDTO.java
@@ -1,0 +1,27 @@
+package com.Mybuddy.Myb.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PedidoResponseDTO {
+    private Long id;
+    private Long clienteId;
+    private String clienteNome;
+    private Long petshopId;
+    private String petshopNome;
+    private EnderecoEntregaDTO enderecoEntrega;
+    private List<ItemPedidoResponseDTO> itens;
+    private BigDecimal valorTotal;
+    private String status;
+    private LocalDateTime dataCriacao;
+    private LocalDateTime dataAtualizacao;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PetRequestDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PetRequestDTO.java
@@ -68,4 +68,7 @@ public class PetRequestDTO {
 
     @Size(max = 100, message = "O estado deve ter no máximo 100 caracteres.")
     private String estado;
+
+    @Size(max = 1000, message = "A descrição deve ter no máximo 1000 caracteres.")
+    private String descricao;
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PetResponse.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PetResponse.java
@@ -22,5 +22,6 @@ public record PetResponse(
         boolean vacinado,
         boolean castrado,
         String cidade,
-        String estado
+        String estado,
+        String descricao
 ) {}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PetshopRequestDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PetshopRequestDTO.java
@@ -1,0 +1,38 @@
+package com.Mybuddy.Myb.DTO;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PetshopRequestDTO {
+
+    @NotBlank(message = "O nome fantasia é obrigatório.")
+    @Size(max = 150, message = "O nome fantasia deve ter no máximo 150 caracteres.")
+    private String nomeFantasia;
+
+    @Email(message = "O e-mail de contato deve ser válido.")
+    @Size(max = 100, message = "O e-mail de contato deve ter no máximo 100 caracteres.")
+    private String emailContato;
+
+    @NotBlank(message = "O CNPJ é obrigatório.")
+    @Pattern(regexp = "\\d{14}", message = "O CNPJ deve conter exatamente 14 dígitos numéricos (apenas números).")
+    private String cnpj;
+
+    @Size(max = 20, message = "O telefone de contato deve ter no máximo 20 caracteres.")
+    private String telefoneContato;
+
+    @Size(max = 255, message = "O endereço deve ter no máximo 255 caracteres.")
+    private String endereco;
+
+    private String descricao;
+
+    @Size(max = 100, message = "O website deve ter no máximo 100 caracteres.")
+    private String website;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PetshopResponseDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/PetshopResponseDTO.java
@@ -1,0 +1,21 @@
+package com.Mybuddy.Myb.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PetshopResponseDTO {
+    private Long id;
+    private String nomeFantasia;
+    private String emailContato;
+    private String cnpj;
+    private String telefoneContato;
+    private String endereco;
+    private String descricao;
+    private String website;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/ProdutoRequestDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/ProdutoRequestDTO.java
@@ -1,0 +1,37 @@
+package com.Mybuddy.Myb.DTO;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProdutoRequestDTO {
+
+    @NotBlank(message = "O nome do produto é obrigatório.")
+    @Size(max = 150, message = "O nome do produto deve ter no máximo 150 caracteres.")
+    private String nome;
+
+    private String descricao;
+
+    @NotNull(message = "O preço do produto é obrigatório.")
+    @DecimalMin(value = "0.01", message = "O preço do produto deve ser maior ou igual a 0.01.")
+    private BigDecimal preco;
+
+    @NotNull(message = "A quantidade em estoque é obrigatória.")
+    @Min(value = 0, message = "A quantidade em estoque deve ser maior ou igual a 0.")
+    private Integer estoque;
+
+    @NotNull(message = "O ID da subcategoria é obrigatório.")
+    private Long subCategoriaId;
+
+    private List<String> imagens;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/ProdutoResponseDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/ProdutoResponseDTO.java
@@ -1,0 +1,29 @@
+package com.Mybuddy.Myb.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProdutoResponseDTO {
+    private Long id;
+    private String nome;
+    private String descricao;
+    private BigDecimal preco;
+    private Integer estoque;
+    private String status;
+    private Long subCategoriaId;
+    private String subCategoriaNome;
+    private Long categoriaId;
+    private String categoriaNome;
+    private Long petshopId;
+    private String petshopNome;
+    private List<String> imagens;
+    private Double notaMedia;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/RegistrarInteresseRequest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/RegistrarInteresseRequest.java
@@ -1,5 +1,7 @@
 package com.Mybuddy.Myb.DTO;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -8,5 +10,17 @@ public record RegistrarInteresseRequest(
         Long petId,
 
         @Size(max = 500, message = "A mensagem não pode exceder 500 caracteres")
-        String mensagem
+        String mensagem,
+
+        @NotBlank(message = "O CPF do adotante é obrigatório.")
+        @Size(min = 11, max = 14, message = "CPF inválido.")
+        String cpfAdotante,
+
+        @NotNull(message = "A idade do adotante é obrigatória.")
+        @Min(value = 18, message = "Você deve ter pelo menos 18 anos para adotar.")
+        Integer idadeAdotante,
+
+        @NotBlank(message = "O motivo da adoção é obrigatório.")
+        @Size(max = 500, message = "O motivo não pode exceder 500 caracteres.")
+        String motivoAdocao
 ) {}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/SubCategoriaRequestDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/SubCategoriaRequestDTO.java
@@ -1,0 +1,21 @@
+package com.Mybuddy.Myb.DTO;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubCategoriaRequestDTO {
+
+    @NotBlank(message = "O nome da subcategoria é obrigatório.")
+    @Size(max = 100, message = "O nome da subcategoria deve ter no máximo 100 caracteres.")
+    private String nome;
+
+    @NotNull(message = "O ID da categoria pai é obrigatório.")
+    private Long categoriaId;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/SubCategoriaResponseDTO.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/DTO/SubCategoriaResponseDTO.java
@@ -1,0 +1,14 @@
+package com.Mybuddy.Myb.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SubCategoriaResponseDTO {
+    private Long id;
+    private String nome;
+    private Long categoriaId;
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Exception/Handler/GlobalExceptionHandler.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Exception/Handler/GlobalExceptionHandler.java
@@ -21,7 +21,7 @@ import java.util.Map;
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
-    private static final Logger logger = LoggerFactory.getLogger(OrganizacaoController.class);
+    private static final Logger logger = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleValidationExceptions(MethodArgumentNotValidException ex, WebRequest request) {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/InteresseAdocao.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/InteresseAdocao.java
@@ -37,6 +37,12 @@ public class InteresseAdocao implements Identifiable {
 
     private String mensagem;
 
+    private String cpfAdotante;
+
+    private Integer idadeAdotante;
+
+    private String motivoAdocao;
+
     @CreatedDate
     private LocalDateTime criadoEm;
 

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Pedido.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Pedido.java
@@ -40,6 +40,7 @@ public class Pedido {
     @OneToMany(mappedBy = "pedido", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonManagedReference
     @ToString.Exclude
+    @org.hibernate.annotations.BatchSize(size = 20)
     private List<ItemPedido> itens = new ArrayList<>();
 
     @Column(nullable = false, precision = 10, scale = 2)

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Pet.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Pet.java
@@ -63,6 +63,8 @@ public class Pet implements Identifiable {
 
     private Double peso;
 
+    private String descricao;
+
     @CreatedDate
     private LocalDateTime dataCriacao;
 

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Produto.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Model/Produto.java
@@ -53,11 +53,13 @@ public class Produto {
     @OneToMany(mappedBy = "produto", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonManagedReference(value = "produto-fotos")
     @ToString.Exclude
+    @org.hibernate.annotations.BatchSize(size = 20)
     private Set<FotoProduto> fotos = new HashSet<>();
 
     @OneToMany(mappedBy = "produto", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JsonManagedReference(value = "produto-avaliacoes")
     @ToString.Exclude
+    @org.hibernate.annotations.BatchSize(size = 20)
     private Set<AvaliacaoProduto> avaliacoes = new HashSet<>();
 
     @CreationTimestamp

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/MybApplication.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/MybApplication.java
@@ -12,6 +12,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @SpringBootApplication
 @EnableAsync
+@SuppressWarnings("null")
 public class MybApplication {
 
 	@Value("${file.upload-dir}")

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/CategoriaRepository.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/CategoriaRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface CategoriaRepository extends JpaRepository<Categoria, Long> {
     Optional<Categoria> findByNome(String nome);
+    boolean existsByNomeIgnoreCase(String nome);
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/FotoProdutoRepository.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/FotoProdutoRepository.java
@@ -1,0 +1,10 @@
+package com.Mybuddy.Myb.Repository.jpa;
+
+import com.Mybuddy.Myb.Model.FotoProduto;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FotoProdutoRepository extends JpaRepository<FotoProduto, Long> {
+    void deleteByProdutoId(Long produtoId);
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/PedidoRepository.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/PedidoRepository.java
@@ -10,4 +10,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface PedidoRepository extends JpaRepository<Pedido, Long> {
     java.util.List<Pedido> findByPetshopId(Long petshopId);
+    java.util.List<Pedido> findByClienteId(Long clienteId);
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/PetshopRepository.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/PetshopRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface PetshopRepository extends JpaRepository<Petshop, Long> {
 
     Optional<Petshop> findByCnpj(String cnpj);
+    boolean existsByCnpj(String cnpj);
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/ProdutoRepository.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/ProdutoRepository.java
@@ -2,6 +2,7 @@ package com.Mybuddy.Myb.Repository.jpa;
 
 import com.Mybuddy.Myb.Model.Produto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,7 +11,7 @@ import java.util.List;
  * Repositório JPA para a entidade Produto (PostgreSQL).
  */
 @Repository
-public interface ProdutoRepository extends JpaRepository<Produto, Long> {
+public interface ProdutoRepository extends JpaRepository<Produto, Long>, JpaSpecificationExecutor<Produto> {
 
     /**
      * Busca os produtos pelo ID numérico do petshop associado.

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/SubCategoriaRepository.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/jpa/SubCategoriaRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface SubCategoriaRepository extends JpaRepository<SubCategoria, Long> {
     Optional<SubCategoria> findByNomeAndCategoriaId(String nome, Long categoriaId);
+    boolean existsByNomeAndCategoriaId(String nome, Long categoriaId);
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/mongo/UsuarioRepository.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Repository/mongo/UsuarioRepository.java
@@ -18,4 +18,6 @@ public interface UsuarioRepository extends MongoRepository<Usuario, Long> {
     Optional<Usuario> findByKeycloakId(String keycloakId);
 
     Boolean existsByKeycloakId(String keycloakId);
+
+    java.util.List<Usuario> findByPetshopId(Long petshopId);
 }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/AuthService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/AuthService.java
@@ -9,6 +9,7 @@ import com.Mybuddy.Myb.Repository.mongo.RoleRepository;
 import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
 import com.Mybuddy.Myb.Security.ERole;
 import com.Mybuddy.Myb.Security.Role;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,22 +18,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Service
+@RequiredArgsConstructor
 public class AuthService {
 
     private final UsuarioRepository usuarioRepository;
     private final RoleRepository roleRepository;
     private final PasswordEncoder encoder;
     private final OrganizacaoService organizacaoService;
-
-    public AuthService(UsuarioRepository usuarioRepository,
-                       RoleRepository roleRepository,
-                       PasswordEncoder encoder,
-                       OrganizacaoService organizacaoService) {
-        this.usuarioRepository = usuarioRepository;
-        this.roleRepository = roleRepository;
-        this.encoder = encoder;
-        this.organizacaoService = organizacaoService;
-    }
 
     // TODO MY-110: avaliar migração do cadastro para Keycloak Admin API
     @Transactional

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/AvaliacaoProdutoService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/AvaliacaoProdutoService.java
@@ -1,0 +1,70 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.AvaliacaoProdutoRequestDTO;
+import com.Mybuddy.Myb.DTO.AvaliacaoProdutoResponseDTO;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.AvaliacaoProduto;
+import com.Mybuddy.Myb.Model.Produto;
+import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Repository.jpa.AvaliacaoProdutoRepository;
+import com.Mybuddy.Myb.Repository.jpa.ProdutoRepository;
+import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AvaliacaoProdutoService {
+
+    private final AvaliacaoProdutoRepository avaliacaoProdutoRepository;
+    private final ProdutoRepository produtoRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    @Transactional
+    public AvaliacaoProdutoResponseDTO criar(Long produtoId, AvaliacaoProdutoRequestDTO request, Usuario usuario) {
+        Produto produto = produtoRepository.findById(produtoId)
+                .orElseThrow(() -> new ResourceNotFoundException("Produto não encontrado com ID: " + produtoId));
+
+        AvaliacaoProduto avaliacao = AvaliacaoProduto.builder()
+                .produto(produto)
+                .clienteId(usuario.getId())
+                .nota(request.getNota())
+                .comentario(request.getComentario())
+                .build();
+
+        AvaliacaoProduto salvo = avaliacaoProdutoRepository.save(avaliacao);
+        return toResponseDTO(salvo, usuario.getNome());
+    }
+
+    @Transactional(readOnly = true)
+    public List<AvaliacaoProdutoResponseDTO> listarPorProduto(Long produtoId) {
+        if (!produtoRepository.existsById(produtoId)) {
+            throw new ResourceNotFoundException("Produto não encontrado com ID: " + produtoId);
+        }
+
+        return avaliacaoProdutoRepository.findByProdutoId(produtoId).stream()
+                .map(av -> {
+                    String clienteNome = usuarioRepository.findById(av.getClienteId())
+                            .map(Usuario::getNome)
+                            .orElse("Usuário do MyBuddy");
+                    return toResponseDTO(av, clienteNome);
+                })
+                .collect(Collectors.toList());
+    }
+
+    private AvaliacaoProdutoResponseDTO toResponseDTO(AvaliacaoProduto av, String clienteNome) {
+        return AvaliacaoProdutoResponseDTO.builder()
+                .id(av.getId())
+                .produtoId(av.getProduto().getId())
+                .clienteId(av.getClienteId())
+                .clienteNome(clienteNome)
+                .nota(av.getNota())
+                .comentario(av.getComentario())
+                .dataCriacao(av.getDataCriacao())
+                .build();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/CampanhaDoacaoService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/CampanhaDoacaoService.java
@@ -1,5 +1,6 @@
 package com.Mybuddy.Myb.Service;
 
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
 import com.Mybuddy.Myb.Model.CampanhaDoacao;
 import com.Mybuddy.Myb.Repository.mongo.CampanhaDoacaoRepository;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +53,7 @@ public class CampanhaDoacaoService {
                     campanha.setStatus(dadosNovos.getStatus());
                     return repository.save(campanha);
                 })
-                .orElseThrow(() -> new RuntimeException("Campanha não encontrada: " + id));
+                .orElseThrow(() -> new ResourceNotFoundException("Campanha não encontrada: " + id));
     }
 
     public void deletar(Long id) {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/CategoriaService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/CategoriaService.java
@@ -1,0 +1,95 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.CategoriaRequestDTO;
+import com.Mybuddy.Myb.DTO.CategoriaResponseDTO;
+import com.Mybuddy.Myb.DTO.SubCategoriaRequestDTO;
+import com.Mybuddy.Myb.DTO.SubCategoriaResponseDTO;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.Categoria;
+import com.Mybuddy.Myb.Model.SubCategoria;
+import com.Mybuddy.Myb.Repository.jpa.CategoriaRepository;
+import com.Mybuddy.Myb.Repository.jpa.SubCategoriaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoriaService {
+
+    private final CategoriaRepository categoriaRepository;
+    private final SubCategoriaRepository subCategoriaRepository;
+
+    @Transactional(readOnly = true)
+    public List<CategoriaResponseDTO> listarTodas() {
+        return categoriaRepository.findAll().stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public CategoriaResponseDTO buscarPorId(Long id) {
+        Categoria categoria = categoriaRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Categoria não encontrada com o ID: " + id));
+        return toResponseDTO(categoria);
+    }
+
+    @Transactional
+    public CategoriaResponseDTO criar(CategoriaRequestDTO request) {
+        if (categoriaRepository.existsByNomeIgnoreCase(request.getNome())) {
+            throw new IllegalArgumentException("Já existe uma categoria com o nome: " + request.getNome());
+        }
+        Categoria categoria = Categoria.builder()
+                .nome(request.getNome())
+                .build();
+        return toResponseDTO(categoriaRepository.save(categoria));
+    }
+
+    @Transactional
+    public SubCategoriaResponseDTO criarSubcategoria(SubCategoriaRequestDTO request) {
+        Categoria categoria = categoriaRepository.findById(request.getCategoriaId())
+                .orElseThrow(() -> new ResourceNotFoundException("Categoria pai não encontrada com o ID: " + request.getCategoriaId()));
+
+        if (subCategoriaRepository.existsByNomeAndCategoriaId(request.getNome(), request.getCategoriaId())) {
+            throw new IllegalArgumentException("Já existe uma subcategoria com este nome para esta categoria.");
+        }
+
+        SubCategoria subCategoria = SubCategoria.builder()
+                .nome(request.getNome())
+                .categoria(categoria)
+                .build();
+
+        SubCategoria salvo = subCategoriaRepository.save(subCategoria);
+        return toSubResponseDTO(salvo);
+    }
+
+    @Transactional
+    public void deletar(Long id) {
+        if (!categoriaRepository.existsById(id)) {
+            throw new ResourceNotFoundException("Categoria não encontrada com o ID: " + id);
+        }
+        categoriaRepository.deleteById(id);
+    }
+
+    @Transactional
+    public void deletarSubcategoria(Long subcategoriaId) {
+        if (!subCategoriaRepository.existsById(subcategoriaId)) {
+            throw new ResourceNotFoundException("Subcategoria não encontrada com o ID: " + subcategoriaId);
+        }
+        subCategoriaRepository.deleteById(subcategoriaId);
+    }
+
+    private CategoriaResponseDTO toResponseDTO(Categoria categoria) {
+        List<SubCategoriaResponseDTO> subs = categoria.getSubcategorias().stream()
+                .map(this::toSubResponseDTO)
+                .collect(Collectors.toList());
+        return new CategoriaResponseDTO(categoria.getId(), categoria.getNome(), subs);
+    }
+
+    private SubCategoriaResponseDTO toSubResponseDTO(SubCategoria sub) {
+        return new SubCategoriaResponseDTO(sub.getId(), sub.getNome(), sub.getCategoria().getId());
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/FotoPetService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/FotoPetService.java
@@ -2,6 +2,7 @@ package com.Mybuddy.Myb.Service;
 
 import com.Mybuddy.Myb.Model.Arquivo;
 import com.Mybuddy.Myb.Repository.mongo.ArquivoRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -18,15 +19,12 @@ import java.util.UUID;
  * Persiste os bytes dos arquivos diretamente no MongoDB para garantir resiliência e alta disponibilidade.
  */
 @Service
+@RequiredArgsConstructor
 public class FotoPetService {
 
     private static final Logger log = LoggerFactory.getLogger(FotoPetService.class);
 
     private final ArquivoRepository arquivoRepository;
-
-    public FotoPetService(ArquivoRepository arquivoRepository) {
-        this.arquivoRepository = arquivoRepository;
-    }
 
     /**
      * Salva um arquivo/foto no MongoDB.

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/InteresseAdocaoService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/InteresseAdocaoService.java
@@ -2,10 +2,13 @@ package com.Mybuddy.Myb.Service;
 
 import com.Mybuddy.Myb.DTO.InteresseAdocaoMapper;
 import com.Mybuddy.Myb.DTO.InteresseResponse;
+import com.Mybuddy.Myb.DTO.RegistrarInteresseRequest;
 import com.Mybuddy.Myb.Model.*;
 import com.Mybuddy.Myb.Repository.mongo.InteresseAdocaoRepository;
 import com.Mybuddy.Myb.Repository.mongo.PetRepository;
 import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,27 +16,20 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class InteresseAdocaoService {
 
     private final InteresseAdocaoRepository interesseRepo;
     private final UsuarioRepository usuarioRepo;
     private final PetRepository petRepo;
 
-    public InteresseAdocaoService(InteresseAdocaoRepository interesseRepo,
-                                  UsuarioRepository usuarioRepo,
-                                  PetRepository petRepo) {
-        this.interesseRepo = interesseRepo;
-        this.usuarioRepo = usuarioRepo;
-        this.petRepo = petRepo;
-    }
-
     @Transactional
-    public InteresseResponse manifestarInteresse(Long usuarioId, Long petId, String mensagem) {
+    public InteresseResponse manifestarInteresse(Long usuarioId, RegistrarInteresseRequest req) {
         Usuario usuario = usuarioRepo.findById(usuarioId)
-                .orElseThrow(() -> new IllegalArgumentException("Usuário não encontrado: " + usuarioId));
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário não encontrado: " + usuarioId));
 
-        Pet pet = petRepo.findById(petId)
-                .orElseThrow(() -> new IllegalArgumentException("Pet não encontrado: " + petId));
+        Pet pet = petRepo.findById(req.petId())
+                .orElseThrow(() -> new ResourceNotFoundException("Pet não encontrado: " + req.petId()));
 
         if (!pet.getStatusAdocao().equals(StatusAdocao.DISPONIVEL)) {
             throw new IllegalStateException("Pet não está disponível para adoção no momento");
@@ -46,7 +42,10 @@ public class InteresseAdocaoService {
         InteresseAdocao interesse = new InteresseAdocao();
         interesse.setUsuario(usuario);
         interesse.setPet(pet);
-        interesse.setMensagem(mensagem);
+        interesse.setMensagem(req.mensagem());
+        interesse.setCpfAdotante(req.cpfAdotante());
+        interesse.setIdadeAdotante(req.idadeAdotante());
+        interesse.setMotivoAdocao(req.motivoAdocao());
         interesse.setStatus(StatusInteresse.PENDENTE);
         interesse.setCriadoEm(LocalDateTime.now());
 
@@ -62,7 +61,7 @@ public class InteresseAdocaoService {
     @Transactional
     public InteresseResponse atualizarStatus(Long interesseId, StatusInteresse novoStatus, Long userOrgId, boolean isAdmin) {
         InteresseAdocao interesse = interesseRepo.findById(interesseId)
-                .orElseThrow(() -> new IllegalArgumentException("Interesse não encontrado: " + interesseId));
+                .orElseThrow(() -> new ResourceNotFoundException("Interesse não encontrado: " + interesseId));
 
         if (!isAdmin) {
             if (interesse.getPet() == null || interesse.getPet().getOrganizacao() == null ||

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/KeycloakUserSyncService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/KeycloakUserSyncService.java
@@ -5,6 +5,7 @@ import com.Mybuddy.Myb.Repository.mongo.RoleRepository;
 import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
 import com.Mybuddy.Myb.Security.ERole;
 import com.Mybuddy.Myb.Security.Role;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,15 +16,11 @@ import java.util.Map;
 import java.util.Set;
 
 @Service
+@RequiredArgsConstructor
 public class KeycloakUserSyncService {
 
     private final UsuarioRepository usuarioRepository;
     private final RoleRepository roleRepository;
-
-    public KeycloakUserSyncService(UsuarioRepository usuarioRepository, RoleRepository roleRepository) {
-        this.usuarioRepository = usuarioRepository;
-        this.roleRepository = roleRepository;
-    }
 
     @Transactional
     public Usuario syncUsuario(Jwt jwt) {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/OrganizacaoService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/OrganizacaoService.java
@@ -6,6 +6,7 @@ import com.Mybuddy.Myb.Exception.ConflictException;
 import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
 import com.Mybuddy.Myb.Model.Organizacao;
 import com.Mybuddy.Myb.Repository.mongo.OrganizacaoRepository;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -16,15 +17,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class OrganizacaoService {
 
     private static final Logger log = LoggerFactory.getLogger(OrganizacaoService.class);
 
     private final OrganizacaoRepository organizacaoRepository;
-
-    public OrganizacaoService(OrganizacaoRepository organizacaoRepository) {
-        this.organizacaoRepository = organizacaoRepository;
-    }
 
     @Transactional
     public Organizacao criarOrganizacao(Organizacao organizacao) {

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/PaymentService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/PaymentService.java
@@ -10,7 +10,6 @@ import com.Mybuddy.Myb.DTO.PaymentRequestDTO;
 import com.Mybuddy.Myb.Model.Payment;
 import com.Mybuddy.Myb.Model.PaymentStatus;
 import com.Mybuddy.Myb.Model.Usuario;
-import com.Mybuddy.Myb.Model.CampanhaDoacao;
 import com.Mybuddy.Myb.Model.Pedido;
 import com.Mybuddy.Myb.Model.StatusPedido;
 import com.Mybuddy.Myb.Repository.jpa.PaymentRepository;
@@ -32,6 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@SuppressWarnings("null")
 public class PaymentService {
     
     private final PaymentRepository paymentRepository;

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/PedidoService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/PedidoService.java
@@ -1,0 +1,251 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.*;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.*;
+import com.Mybuddy.Myb.Repository.jpa.PedidoRepository;
+import com.Mybuddy.Myb.Repository.jpa.PetshopRepository;
+import com.Mybuddy.Myb.Repository.jpa.ProdutoRepository;
+import com.Mybuddy.Myb.Security.ERole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PedidoService {
+
+    private final PedidoRepository pedidoRepository;
+    private final ProdutoRepository produtoRepository;
+    private final PetshopRepository petshopRepository;
+
+    @Transactional
+    public PedidoResponseDTO criar(PedidoRequestDTO request, Usuario usuario) {
+        Petshop petshop = petshopRepository.findById(request.getPetshopId())
+                .orElseThrow(() -> new ResourceNotFoundException("Petshop não encontrado com ID: " + request.getPetshopId()));
+
+        Pedido pedido = new Pedido();
+        pedido.setClienteId(usuario.getId());
+        pedido.setPetshop(petshop);
+        pedido.setStatus(StatusPedido.PENDENTE);
+
+        // Mapear EnderecoEntrega
+        EnderecoEntrega endereco = EnderecoEntrega.builder()
+                .cep(request.getEnderecoEntrega().getCep())
+                .logradouro(request.getEnderecoEntrega().getLogradouro())
+                .numero(request.getEnderecoEntrega().getNumero())
+                .complemento(request.getEnderecoEntrega().getComplemento())
+                .bairro(request.getEnderecoEntrega().getBairro())
+                .cidade(request.getEnderecoEntrega().getCidade())
+                .estado(request.getEnderecoEntrega().getEstado())
+                .build();
+        pedido.setEnderecoEntrega(endereco);
+
+        BigDecimal total = BigDecimal.ZERO;
+
+        for (ItemPedidoRequestDTO itemReq : request.getItens()) {
+            Produto produto = produtoRepository.findById(itemReq.getProdutoId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Produto não encontrado com ID: " + itemReq.getProdutoId()));
+
+            if (produto.getStatus() != StatusProduto.ATIVO) {
+                throw new IllegalArgumentException("O produto '" + produto.getNome() + "' não está ativo para venda.");
+            }
+
+            if (!produto.getPetshop().getId().equals(petshop.getId())) {
+                throw new IllegalArgumentException("O produto '" + produto.getNome() + "' não pertence ao Petshop selecionado.");
+            }
+
+            if (produto.getEstoque() < itemReq.getQuantidade()) {
+                throw new IllegalArgumentException("Estoque insuficiente para o produto '" + produto.getNome() + "'. Disponível: " + produto.getEstoque());
+            }
+
+            // Decrementar estoque
+            produto.setEstoque(produto.getEstoque() - itemReq.getQuantidade());
+            if (produto.getEstoque() == 0) {
+                produto.setStatus(StatusProduto.ESGOTADO);
+            }
+            produtoRepository.save(produto);
+
+            // Criar ItemPedido
+            ItemPedido item = new ItemPedido();
+            item.setProduto(produto);
+            item.setQuantidade(itemReq.getQuantidade());
+            item.setPrecoUnitario(produto.getPreco());
+
+            pedido.addItem(item);
+            total = total.add(item.getSubtotal());
+        }
+
+        pedido.setValorTotal(total);
+        Pedido salvo = pedidoRepository.save(pedido);
+
+        return toResponseDTO(salvo);
+    }
+
+    @Transactional(readOnly = true)
+    public PedidoResponseDTO buscarPorIdDTO(Long id, Usuario usuario) {
+        Pedido pedido = pedidoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Pedido não encontrado com ID: " + id));
+
+        boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
+        boolean isOwner = pedido.getClienteId().equals(usuario.getId());
+        boolean isSeller = pedido.getPetshop().getId().equals(usuario.getPetshopId());
+
+        if (!isAdmin && !isOwner && !isSeller) {
+            throw new AuthorizationDeniedException("Você não tem permissão para visualizar este pedido.");
+        }
+
+        return toResponseDTO(pedido);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PedidoResponseDTO> listarPedidosCliente(Usuario usuario) {
+        return pedidoRepository.findByClienteId(usuario.getId()).stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public List<PedidoResponseDTO> listarPedidosPetshop(Usuario usuario) {
+        if (usuario.getPetshopId() == null) {
+            throw new IllegalArgumentException("O usuário não possui um petshop cadastrado.");
+        }
+        return pedidoRepository.findByPetshopId(usuario.getPetshopId()).stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public PedidoResponseDTO atualizarStatus(Long id, StatusPedido novoStatus, Usuario usuario) {
+        Pedido pedido = pedidoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Pedido não encontrado com ID: " + id));
+
+        boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
+        boolean isSeller = pedido.getPetshop().getId().equals(usuario.getPetshopId());
+
+        if (!isAdmin && !isSeller) {
+            throw new AuthorizationDeniedException("Você não tem permissão para atualizar o status deste pedido.");
+        }
+
+        validarTransicaoStatus(pedido.getStatus(), novoStatus);
+
+        pedido.setStatus(novoStatus);
+
+        if (novoStatus == StatusPedido.CANCELADO) {
+            devolverEstoque(pedido);
+        }
+
+        return toResponseDTO(pedidoRepository.save(pedido));
+    }
+
+    @Transactional
+    public PedidoResponseDTO cancelar(Long id, Usuario usuario) {
+        Pedido pedido = pedidoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Pedido não encontrado com ID: " + id));
+
+        boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
+        boolean isOwner = pedido.getClienteId().equals(usuario.getId());
+        boolean isSeller = pedido.getPetshop().getId().equals(usuario.getPetshopId());
+
+        if (!isAdmin && !isOwner && !isSeller) {
+            throw new AuthorizationDeniedException("Você não tem permissão para cancelar este pedido.");
+        }
+
+        if (pedido.getStatus() == StatusPedido.CANCELADO) {
+            throw new IllegalStateException("O pedido já está cancelado.");
+        }
+
+        // Regra aprovada: Só pode cancelar se estiver PENDENTE ou PAGO
+        if (pedido.getStatus() != StatusPedido.PENDENTE && pedido.getStatus() != StatusPedido.PAGO) {
+            throw new IllegalStateException("Não é possível cancelar um pedido que já está " + pedido.getStatus().name() + ".");
+        }
+
+        pedido.setStatus(StatusPedido.CANCELADO);
+        devolverEstoque(pedido);
+
+        return toResponseDTO(pedidoRepository.save(pedido));
+    }
+
+    private void devolverEstoque(Pedido pedido) {
+        for (ItemPedido item : pedido.getItens()) {
+            Produto produto = item.getProduto();
+            produto.setEstoque(produto.getEstoque() + item.getQuantidade());
+            if (produto.getStatus() == StatusProduto.ESGOTADO) {
+                produto.setStatus(StatusProduto.ATIVO);
+            }
+            produtoRepository.save(produto);
+        }
+    }
+
+    private void validarTransicaoStatus(StatusPedido atual, StatusPedido novo) {
+        if (atual == StatusPedido.CANCELADO) {
+            throw new IllegalArgumentException("Não é possível alterar o status de um pedido cancelado.");
+        }
+        if (atual == StatusPedido.ENTREGUE) {
+            throw new IllegalArgumentException("Não é possível alterar o status de um pedido já entregue.");
+        }
+
+        boolean valida = false;
+        switch (atual) {
+            case PENDENTE:
+                valida = (novo == StatusPedido.PAGO || novo == StatusPedido.CANCELADO);
+                break;
+            case PAGO:
+                valida = (novo == StatusPedido.PROCESSANDO || novo == StatusPedido.CANCELADO);
+                break;
+            case PROCESSANDO:
+                valida = (novo == StatusPedido.ENVIADO || novo == StatusPedido.CANCELADO);
+                break;
+            case ENVIADO:
+                valida = (novo == StatusPedido.ENTREGUE); // Se já foi enviado, não pode cancelar diretamente via transição normal
+                break;
+            default:
+                break;
+        }
+
+        if (!valida) {
+            throw new IllegalArgumentException("Transição de status inválida de " + atual.name() + " para " + novo.name() + ".");
+        }
+    }
+
+    private PedidoResponseDTO toResponseDTO(Pedido p) {
+        List<ItemPedidoResponseDTO> itens = p.getItens().stream()
+                .map(item -> ItemPedidoResponseDTO.builder()
+                        .produtoId(item.getProduto().getId())
+                        .produtoNome(item.getProduto().getNome())
+                        .quantidade(item.getQuantidade())
+                        .precoUnitario(item.getPrecoUnitario())
+                        .subtotal(item.getSubtotal())
+                        .build())
+                .collect(Collectors.toList());
+
+        EnderecoEntregaDTO endereco = EnderecoEntregaDTO.builder()
+                .cep(p.getEnderecoEntrega().getCep())
+                .logradouro(p.getEnderecoEntrega().getLogradouro())
+                .numero(p.getEnderecoEntrega().getNumero())
+                .complemento(p.getEnderecoEntrega().getComplemento())
+                .bairro(p.getEnderecoEntrega().getBairro())
+                .cidade(p.getEnderecoEntrega().getCidade())
+                .estado(p.getEnderecoEntrega().getEstado())
+                .build();
+
+        return PedidoResponseDTO.builder()
+                .id(p.getId())
+                .clienteId(p.getClienteId())
+                .clienteNome(null) // Pode ser preenchido por quem consome buscando no mongo se necessário
+                .petshopId(p.getPetshop().getId())
+                .petshopNome(p.getPetshop().getNomeFantasia())
+                .enderecoEntrega(endereco)
+                .itens(itens)
+                .valorTotal(p.getValorTotal())
+                .status(p.getStatus().name())
+                .dataCriacao(p.getDataCriacao())
+                .dataAtualizacao(p.getDataAtualizacao())
+                .build();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/PetService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/PetService.java
@@ -20,6 +20,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class PetService {
 
     private static final Logger log = LoggerFactory.getLogger(PetService.class);
@@ -38,16 +41,6 @@ public class PetService {
     private final InteresseAdocaoRepository interesseRepo;
     private final OrganizacaoRepository organizacaoRepository;
     private final MongoTemplate mongoTemplate;
-
-    public PetService(PetRepository petRepository,
-                      InteresseAdocaoRepository interesseRepo,
-                      OrganizacaoRepository organizacaoRepository,
-                      MongoTemplate mongoTemplate) {
-        this.petRepository = petRepository;
-        this.interesseRepo = interesseRepo;
-        this.organizacaoRepository = organizacaoRepository;
-        this.mongoTemplate = mongoTemplate;
-    }
 
     @Transactional
     public PetResponse criarPet(PetRequestDTO petRequestDTO) {
@@ -77,6 +70,7 @@ public class PetService {
         pet.setCidade(petRequestDTO.getCidade());
         pet.setEstado(petRequestDTO.getEstado());
         pet.setOrganizacao(organizacao);
+        pet.setDescricao(petRequestDTO.getDescricao());
         pet.setStatusAdocao(
                 petRequestDTO.getStatusAdocao() != null
                         ? petRequestDTO.getStatusAdocao()
@@ -104,7 +98,7 @@ public class PetService {
         log.debug("Iniciando atualização do pet ID: {}", id);
 
         Pet petExistente = petRepository.findById(id)
-                .orElseThrow(() -> new IllegalStateException("Pet com ID " + id + " não encontrado."));
+                .orElseThrow(() -> new ResourceNotFoundException("Pet com ID " + id + " não encontrado."));
 
         Optional.ofNullable(petRequestDTO.getNome()).ifPresent(petExistente::setNome);
         Optional.ofNullable(petRequestDTO.getCor()).ifPresent(petExistente::setCor);
@@ -116,6 +110,7 @@ public class PetService {
         Optional.ofNullable(petRequestDTO.getPelagem()).ifPresent(petExistente::setPelagem);
         Optional.ofNullable(petRequestDTO.getCidade()).ifPresent(petExistente::setCidade);
         Optional.ofNullable(petRequestDTO.getEstado()).ifPresent(petExistente::setEstado);
+        Optional.ofNullable(petRequestDTO.getDescricao()).ifPresent(petExistente::setDescricao);
 
         petExistente.setMicrochipado(petRequestDTO.isMicrochipado());
         petExistente.setVacinado(petRequestDTO.isVacinado());
@@ -203,7 +198,7 @@ public class PetService {
         log.debug("Iniciando exclusão de pet ID: {}", id);
 
         Pet pet = petRepository.findById(id)
-                .orElseThrow(() -> new IllegalStateException("Pet com ID " + id + " não encontrado."));
+                .orElseThrow(() -> new ResourceNotFoundException("Pet com ID " + id + " não encontrado."));
 
         if (pet.getStatusAdocao() == StatusAdocao.ADOTADO) {
             throw new IllegalStateException(
@@ -324,7 +319,8 @@ public class PetService {
                 p.isVacinado(),
                 p.isCastrado(),
                 p.getCidade(),
-                p.getEstado()
+                p.getEstado(),
+                p.getDescricao()
         );
     }
 

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/PetshopService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/PetshopService.java
@@ -1,0 +1,122 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.PetshopRequestDTO;
+import com.Mybuddy.Myb.DTO.PetshopResponseDTO;
+import com.Mybuddy.Myb.Exception.ConflictException;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.Petshop;
+import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Repository.jpa.PetshopRepository;
+import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
+import com.Mybuddy.Myb.Security.ERole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PetshopService {
+
+    private final PetshopRepository petshopRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    @Transactional
+    public PetshopResponseDTO criar(PetshopRequestDTO request, Usuario usuario) {
+        if (petshopRepository.existsByCnpj(request.getCnpj())) {
+            throw new ConflictException("Já existe um petshop cadastrado com este CNPJ.");
+        }
+
+        if (usuario.getPetshopId() != null) {
+            throw new IllegalArgumentException("Este usuário já possui um petshop associado.");
+        }
+
+        Petshop petshop = Petshop.builder()
+                .nomeFantasia(request.getNomeFantasia())
+                .emailContato(request.getEmailContato())
+                .cnpj(request.getCnpj())
+                .telefoneContato(request.getTelefoneContato())
+                .endereco(request.getEndereco())
+                .descricao(request.getDescricao())
+                .website(request.getWebsite())
+                .build();
+
+        Petshop salvo = petshopRepository.save(petshop);
+
+        // Atualizar o usuário logado com o ID do petshop criado (MongoDB)
+        usuario.setPetshopId(salvo.getId());
+        usuarioRepository.save(usuario);
+
+        return toResponseDTO(salvo);
+    }
+
+    @Transactional(readOnly = true)
+    public PetshopResponseDTO buscarPorId(Long id) {
+        Petshop petshop = petshopRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Petshop não encontrado com o ID: " + id));
+        return toResponseDTO(petshop);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PetshopResponseDTO> listarTodos() {
+        return petshopRepository.findAll().stream()
+                .map(this::toResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public PetshopResponseDTO atualizar(Long id, PetshopRequestDTO request, Usuario usuario) {
+        Petshop petshop = petshopRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Petshop não encontrado com o ID: " + id));
+
+        boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
+        if (!isAdmin && !id.equals(usuario.getPetshopId())) {
+            throw new AuthorizationDeniedException("Você não tem permissão para alterar as informações deste petshop.");
+        }
+
+        if (!petshop.getCnpj().equals(request.getCnpj()) && petshopRepository.existsByCnpj(request.getCnpj())) {
+            throw new ConflictException("Já existe outro petshop cadastrado com este CNPJ.");
+        }
+
+        petshop.setNomeFantasia(request.getNomeFantasia());
+        petshop.setEmailContato(request.getEmailContato());
+        petshop.setCnpj(request.getCnpj());
+        petshop.setTelefoneContato(request.getTelefoneContato());
+        petshop.setEndereco(request.getEndereco());
+        petshop.setDescricao(request.getDescricao());
+        petshop.setWebsite(request.getWebsite());
+
+        return toResponseDTO(petshopRepository.save(petshop));
+    }
+
+    @Transactional
+    public void deletar(Long id) {
+        Petshop petshop = petshopRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Petshop não encontrado com o ID: " + id));
+
+        // Desvincular usuários associados a este petshop no MongoDB
+        List<Usuario> usuarios = usuarioRepository.findByPetshopId(id);
+        for (Usuario u : usuarios) {
+            u.setPetshopId(null);
+            usuarioRepository.save(u);
+        }
+
+        petshopRepository.delete(petshop);
+    }
+
+    private PetshopResponseDTO toResponseDTO(Petshop petshop) {
+        return PetshopResponseDTO.builder()
+                .id(petshop.getId())
+                .nomeFantasia(petshop.getNomeFantasia())
+                .emailContato(petshop.getEmailContato())
+                .cnpj(petshop.getCnpj())
+                .telefoneContato(petshop.getTelefoneContato())
+                .endereco(petshop.getEndereco())
+                .descricao(petshop.getDescricao())
+                .website(petshop.getWebsite())
+                .build();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/ProdutoService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/ProdutoService.java
@@ -1,0 +1,207 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.ProdutoRequestDTO;
+import com.Mybuddy.Myb.DTO.ProdutoResponseDTO;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.*;
+import com.Mybuddy.Myb.Repository.jpa.FotoProdutoRepository;
+import com.Mybuddy.Myb.Repository.jpa.PetshopRepository;
+import com.Mybuddy.Myb.Repository.jpa.ProdutoRepository;
+import com.Mybuddy.Myb.Repository.jpa.SubCategoriaRepository;
+import com.Mybuddy.Myb.Security.ERole;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Predicate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ProdutoService {
+
+    private final ProdutoRepository produtoRepository;
+    private final SubCategoriaRepository subCategoriaRepository;
+    private final PetshopRepository petshopRepository;
+    private final FotoProdutoRepository fotoProdutoRepository;
+
+    @Transactional(readOnly = true)
+    public Page<ProdutoResponseDTO> buscarComFiltros(
+            String busca, Long categoriaId, Long subCategoriaId, Long petshopId,
+            BigDecimal precoMin, BigDecimal precoMax, Pageable pageable) {
+
+        Specification<Produto> spec = (root, query, cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            // Apenas produtos ativos por padrão na busca pública
+            predicates.add(cb.equal(root.get("status"), StatusProduto.ATIVO));
+
+            if (busca != null && !busca.isBlank()) {
+                String term = "%" + busca.toLowerCase() + "%";
+                predicates.add(cb.or(
+                        cb.like(cb.lower(root.get("nome")), term),
+                        cb.like(cb.lower(root.get("descricao")), term)
+                ));
+            }
+
+            if (subCategoriaId != null) {
+                predicates.add(cb.equal(root.get("subCategoria").get("id"), subCategoriaId));
+            } else if (categoriaId != null) {
+                Join<Produto, SubCategoria> subCatJoin = root.join("subCategoria");
+                predicates.add(cb.equal(subCatJoin.get("categoria").get("id"), categoriaId));
+            }
+
+            if (petshopId != null) {
+                predicates.add(cb.equal(root.get("petshop").get("id"), petshopId));
+            }
+
+            if (precoMin != null) {
+                predicates.add(cb.greaterThanOrEqualTo(root.get("preco"), precoMin));
+            }
+
+            if (precoMax != null) {
+                predicates.add(cb.lessThanOrEqualTo(root.get("preco"), precoMax));
+            }
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+
+        return produtoRepository.findAll(spec, pageable).map(this::toResponseDTO);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ProdutoResponseDTO> buscarPorPetshop(Long petshopId, Pageable pageable) {
+        Specification<Produto> spec = (root, query, cb) -> cb.equal(root.get("petshop").get("id"), petshopId);
+        return produtoRepository.findAll(spec, pageable).map(this::toResponseDTO);
+    }
+
+    @Transactional(readOnly = true)
+    public ProdutoResponseDTO buscarPorIdDTO(Long id) {
+        Produto produto = produtoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Produto não encontrado com o ID: " + id));
+        return toResponseDTO(produto);
+    }
+
+    @Transactional
+    public ProdutoResponseDTO criar(ProdutoRequestDTO request, Usuario usuario) {
+        if (usuario.getPetshopId() == null) {
+            throw new IllegalArgumentException("O usuário logado não possui um petshop cadastrado.");
+        }
+
+        Petshop petshop = petshopRepository.findById(usuario.getPetshopId())
+                .orElseThrow(() -> new ResourceNotFoundException("Petshop associado ao usuário não encontrado."));
+
+        SubCategoria subCategoria = subCategoriaRepository.findById(request.getSubCategoriaId())
+                .orElseThrow(() -> new ResourceNotFoundException("Subcategoria não encontrada com ID: " + request.getSubCategoriaId()));
+
+        Produto produto = new Produto();
+        produto.setNome(request.getNome());
+        produto.setDescricao(request.getDescricao());
+        produto.setPreco(request.getPreco());
+        produto.setEstoque(request.getEstoque());
+        produto.setSubCategoria(subCategoria);
+        produto.setPetshop(petshop);
+        produto.setStatus(StatusProduto.ATIVO);
+
+        Produto salvo = produtoRepository.save(produto);
+
+        if (request.getImagens() != null) {
+            for (String url : request.getImagens()) {
+                FotoProduto foto = new FotoProduto();
+                foto.setUrl(url);
+                foto.setProduto(salvo);
+                fotoProdutoRepository.save(foto);
+                salvo.addFoto(foto);
+            }
+        }
+
+        return toResponseDTO(salvo);
+    }
+
+    @Transactional
+    public ProdutoResponseDTO atualizar(Long id, ProdutoRequestDTO request, Usuario usuario) {
+        Produto produto = produtoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Produto não encontrado com ID: " + id));
+
+        boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
+        if (!isAdmin && !produto.getPetshop().getId().equals(usuario.getPetshopId())) {
+            throw new AuthorizationDeniedException("Você não tem permissão para alterar este produto.");
+        }
+
+        SubCategoria subCategoria = subCategoriaRepository.findById(request.getSubCategoriaId())
+                .orElseThrow(() -> new ResourceNotFoundException("Subcategoria não encontrada com ID: " + request.getSubCategoriaId()));
+
+        produto.setNome(request.getNome());
+        produto.setDescricao(request.getDescricao());
+        produto.setPreco(request.getPreco());
+        produto.setEstoque(request.getEstoque());
+        produto.setSubCategoria(subCategoria);
+
+        // Atualizar fotos se enviado
+        if (request.getImagens() != null) {
+            fotoProdutoRepository.deleteByProdutoId(id);
+            produto.getFotos().clear();
+            for (String url : request.getImagens()) {
+                FotoProduto foto = new FotoProduto();
+                foto.setUrl(url);
+                foto.setProduto(produto);
+                fotoProdutoRepository.save(foto);
+                produto.addFoto(foto);
+            }
+        }
+
+        return toResponseDTO(produtoRepository.save(produto));
+    }
+
+    @Transactional
+    public void deletar(Long id, Usuario usuario) {
+        Produto produto = produtoRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Produto não encontrado com ID: " + id));
+
+        boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
+        if (!isAdmin && !produto.getPetshop().getId().equals(usuario.getPetshopId())) {
+            throw new AuthorizationDeniedException("Você não tem permissão para deletar este produto.");
+        }
+
+        produtoRepository.delete(produto);
+    }
+
+    private ProdutoResponseDTO toResponseDTO(Produto p) {
+        List<String> fotos = p.getFotos() == null ? Collections.emptyList() :
+                p.getFotos().stream()
+                        .map(FotoProduto::getUrl)
+                        .collect(Collectors.toList());
+
+        double media = p.getAvaliacoes() == null || p.getAvaliacoes().isEmpty() ? 0.0 :
+                p.getAvaliacoes().stream()
+                        .mapToInt(AvaliacaoProduto::getNota)
+                        .average()
+                        .orElse(0.0);
+
+        return ProdutoResponseDTO.builder()
+                .id(p.getId())
+                .nome(p.getNome())
+                .descricao(p.getDescricao())
+                .preco(p.getPreco())
+                .estoque(p.getEstoque())
+                .status(p.getStatus().name())
+                .subCategoriaId(p.getSubCategoria().getId())
+                .subCategoriaNome(p.getSubCategoria().getNome())
+                .categoriaId(p.getSubCategoria().getCategoria().getId())
+                .categoriaNome(p.getSubCategoria().getCategoria().getNome())
+                .petshopId(p.getPetshop().getId())
+                .petshopNome(p.getPetshop().getNomeFantasia())
+                .imagens(fotos)
+                .notaMedia(media)
+                .build();
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/SequenceGeneratorService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/SequenceGeneratorService.java
@@ -1,6 +1,7 @@
 package com.Mybuddy.Myb.Service;
 
 import com.Mybuddy.Myb.Model.DatabaseSequence;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.stereotype.Service;
@@ -12,13 +13,10 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 import static org.springframework.data.mongodb.core.query.Query.query;
 
 @Service
+@RequiredArgsConstructor
 public class SequenceGeneratorService {
 
     private final MongoOperations mongoOperations;
-
-    public SequenceGeneratorService(MongoOperations mongoOperations) {
-        this.mongoOperations = mongoOperations;
-    }
 
     public long generateSequence(String seqName) {
         DatabaseSequence counter = mongoOperations.findAndModify(

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/UsuarioService.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Service/UsuarioService.java
@@ -1,25 +1,25 @@
 package com.Mybuddy.Myb.Service;
 
+import com.Mybuddy.Myb.Exception.ConflictException;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
 import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class UsuarioService {
 
     public static final String KeycloakUserSyncService = null;
     private final UsuarioRepository usuarioRepository;
 
-    public UsuarioService(UsuarioRepository usuarioRepository) {
-        this.usuarioRepository = usuarioRepository;
-    }
-
     public Usuario criarUsuario(Usuario usuario) {
         if (usuarioRepository.findByEmail(usuario.getEmail()).isPresent()) {
-            throw new IllegalStateException("O e-mail informado já está em uso.");
+            throw new ConflictException("O e-mail informado já está em uso.");
         }
         return usuarioRepository.save(usuario);
     }
@@ -34,7 +34,7 @@ public class UsuarioService {
 
     public Usuario atualizarUsuario(long id, Usuario dadosUsuario) {
         Usuario usuarioExistente = usuarioRepository.findById(id)
-                .orElseThrow(() -> new IllegalStateException("Usuário com ID " + id + " não encontrado."));
+                .orElseThrow(() -> new ResourceNotFoundException("Usuário com ID " + id + " não encontrado."));
 
         usuarioExistente.setNome(dadosUsuario.getNome());
         usuarioExistente.setEmail(dadosUsuario.getEmail());
@@ -46,7 +46,7 @@ public class UsuarioService {
 
     public void deletarUsuario(Long id) {
         if (!usuarioRepository.existsById(id)) {
-            throw new IllegalStateException("Usuário com ID " + id + " não encontrado.");
+            throw new ResourceNotFoundException("Usuário com ID " + id + " não encontrado.");
         }
         usuarioRepository.deleteById(id);
     }

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/DataInitializer.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/DataInitializer.java
@@ -6,6 +6,7 @@ import com.Mybuddy.Myb.Repository.mongo.*;
 import com.Mybuddy.Myb.Security.ERole;
 import com.Mybuddy.Myb.Security.Role;
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +18,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 @Configuration
+@RequiredArgsConstructor
 public class DataInitializer {
 
     private static final Logger log = LoggerFactory.getLogger(DataInitializer.class);
@@ -32,32 +34,6 @@ public class DataInitializer {
     private final ChatRepository chatRepository;
     private final CategoriaRepository categoriaRepository;
     private final SubCategoriaRepository subCategoriaRepository;
-
-    public DataInitializer(
-            UsuarioRepository usuarioRepository,
-            RoleRepository roleRepository,
-            PasswordEncoder encoder,
-            OrganizacaoRepository organizacaoRepository,
-            PetRepository petRepository,
-            PetshopRepository petshopRepository,
-            ProdutoRepository produtoRepository,
-            EventoOngRepository eventoOngRepository,
-            ChatRepository chatRepository,
-            CategoriaRepository categoriaRepository,
-            SubCategoriaRepository subCategoriaRepository
-    ) {
-        this.usuarioRepository = usuarioRepository;
-        this.roleRepository = roleRepository;
-        this.encoder = encoder;
-        this.organizacaoRepository = organizacaoRepository;
-        this.petRepository = petRepository;
-        this.petshopRepository = petshopRepository;
-        this.produtoRepository = produtoRepository;
-        this.eventoOngRepository = eventoOngRepository;
-        this.chatRepository = chatRepository;
-        this.categoriaRepository = categoriaRepository;
-        this.subCategoriaRepository = subCategoriaRepository;
-    }
 
     @PostConstruct
     public void initData() {
@@ -233,6 +209,7 @@ public class DataInitializer {
             if (petRepository.findByNome("Zeus").isEmpty()) {
                 Pet p1 = new Pet("Zeus", "SRD", 2, Especie.CAO, Porte.MEDIO, "Marrom", "Curta", "Macho", myBuddyOrg, true, true, true, "São Paulo", "SP");
                 p1.setId(1L);
+                p1.setDescricao("Zeus é um cãozinho muito alegre, dócil e companheiro. Adora correr em espaços abertos e se dá muito bem com outros cachorros.");
                 FotoPet f1 = new FotoPet();
                 f1.setUrl("https://images.unsplash.com/photo-1543466835-00a7907e9de1?auto=format&fit=crop&q=80&w=600");
                 f1.setPrincipal(true);
@@ -243,6 +220,7 @@ public class DataInitializer {
             if (petRepository.findByNome("Mia").isEmpty()) {
                 Pet p2 = new Pet("Mia", "Persa", 1, Especie.GATO, Porte.PEQUENO, "Branco", "Longa", "Fêmea", myBuddyOrg, true, true, false, "São Paulo", "SP");
                 p2.setId(2L);
+                p2.setDescricao("Mia é uma gatinha calma, carinhosa e muito dorminhoca. Perfeita para apartamentos. Gosta de ser escovada e receber carinho.");
                 FotoPet f2 = new FotoPet();
                 f2.setUrl("https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?auto=format&fit=crop&q=80&w=600");
                 f2.setPrincipal(true);
@@ -253,6 +231,7 @@ public class DataInitializer {
             if (petRepository.findByNome("Thor").isEmpty()) {
                 Pet p3 = new Pet("Thor", "Golden Retriever", 1, Especie.CAO, Porte.GRANDE, "Dourado", "Longa", "Macho", myBuddyOrg, true, true, true, "São Paulo", "SP");
                 p3.setId(3L);
+                p3.setDescricao("Thor é um Golden Retriever brincalhão, inteligente e cheio de energia. Ideal para famílias ativas que adoram passear.");
                 FotoPet f3 = new FotoPet();
                 f3.setUrl("https://images.unsplash.com/photo-1552053831-71594a27632d?auto=format&fit=crop&q=80&w=600");
                 f3.setPrincipal(true);

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/DataInitializer.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/DataInitializer.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 @Configuration
 @RequiredArgsConstructor
+@SuppressWarnings("null")
 public class DataInitializer {
 
     private static final Logger log = LoggerFactory.getLogger(DataInitializer.class);

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
@@ -19,7 +19,7 @@ public class MercadoPagoWebhookValidator {
     public boolean isValid(String xSignature, String xRequestId, String dataId) {
         try{
             if(xSignature == null || xSignature.isBlank()) {
-                log.warn("x-signature ausente no Weebhook MP. requestId={}", xRequestId);
+                log.warn("x-signature ausente no Webhook MP. requestId={}", xRequestId);
                 return false;
             }
 
@@ -35,7 +35,7 @@ public class MercadoPagoWebhookValidator {
             }
 
             if (ts == null || v1 == null) {
-                log.warn("x-signature malformada no Weebhook MP. requestId={}", xRequestId);
+                log.warn("x-signature malformada no Webhook MP. requestId={}", xRequestId);
                 return false;
             }
 

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/java/com/Mybuddy/Myb/Util/MercadoPagoWebhookValidator.java
@@ -11,6 +11,7 @@ import java.util.HexFormat;
 
 @Slf4j
 @Component
+@SuppressWarnings("null")
 public class MercadoPagoWebhookValidator {
 
     @Value("${mercadopago.webhook-secret}")

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/resources/application.properties
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=Myb
 server.port=8081
 
-#Keycloack
+#Keycloak
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080/realms/mybuddy
 spring.security.oauth2.client.registration.keycloak.client-id=mybuddy-backend
 spring.security.oauth2.client.registration.keycloak.client-secret=${KC_CLIENT_SECRET}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Controller/PetControllerTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Controller/PetControllerTest.java
@@ -78,7 +78,7 @@ class PetControllerTest {
                 1L, "Rex", "CAO", "Labrador", 2, "GRANDE", "Amarelo",
                 null, "M", List.of(), "Disponível para Adoção",
                 StatusAdocao.DISPONIVEL, "ONG Teste", 1L,
-                false, true, true, null, null
+                false, true, true, null, null, "Rex é um cão amigável"
         );
 
         adminUser = new Usuario();

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Controller/PetshopControllerTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Controller/PetshopControllerTest.java
@@ -9,6 +9,7 @@ import com.Mybuddy.Myb.Repository.jpa.PedidoRepository;
 import com.Mybuddy.Myb.Repository.jpa.ProdutoRepository;
 import com.Mybuddy.Myb.Repository.mongo.ChatRepository;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
+import com.Mybuddy.Myb.Service.PetshopService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,9 @@ class PetshopControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockitoBean
+    private PetshopService petshopService;
 
     @MockitoBean
     private ProdutoRepository produtoRepository;
@@ -84,9 +88,9 @@ class PetshopControllerTest {
     }
 
     @Test
-    void deveRetornar401QuandoBuscarProdutosSemToken() throws Exception {
+    void deveRetornar403QuandoBuscarProdutosSemToken() throws Exception {
         mockMvc.perform(get("/api/petshop/produtos"))
-                .andExpect(status().isUnauthorized());
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/Interesseadocaoservicetest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/Interesseadocaoservicetest.java
@@ -1,9 +1,11 @@
 package com.Mybuddy.Myb.Service;
 
 import com.Mybuddy.Myb.DTO.InteresseResponse;
+import com.Mybuddy.Myb.DTO.RegistrarInteresseRequest;
 import com.Mybuddy.Myb.Model.*;
 import com.Mybuddy.Myb.Repository.mongo.InteresseAdocaoRepository;
 import com.Mybuddy.Myb.Repository.mongo.PetRepository;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
 import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,6 +40,7 @@ class InteresseAdocaoServiceTest {
     private Usuario usuario;
     private Pet pet;
     private InteresseAdocao interesse;
+    private RegistrarInteresseRequest request;
 
     @BeforeEach
     void setUp() {
@@ -56,7 +59,12 @@ class InteresseAdocaoServiceTest {
         interesse.setUsuario(usuario);
         interesse.setPet(pet);
         interesse.setMensagem("Quero adotar!");
+        interesse.setCpfAdotante("12345678901");
+        interesse.setIdadeAdotante(25);
+        interesse.setMotivoAdocao("Quero um companheiro");
         interesse.setStatus(StatusInteresse.PENDENTE);
+
+        request = new RegistrarInteresseRequest(1L, "Quero adotar!", "12345678901", 25, "Quero um companheiro");
     }
 
     // ===================== MANIFESTAR INTERESSE =====================
@@ -68,7 +76,7 @@ class InteresseAdocaoServiceTest {
         when(interesseRepo.existsByUsuarioAndPet(usuario, pet)).thenReturn(false);
         when(interesseRepo.save(any(InteresseAdocao.class))).thenReturn(interesse);
 
-        InteresseResponse result = interesseAdocaoService.manifestarInteresse(1L, 1L, "Quero adotar!");
+        InteresseResponse result = interesseAdocaoService.manifestarInteresse(1L, request);
 
         assertThat(result).isNotNull();
         verify(interesseRepo, times(1)).save(any(InteresseAdocao.class));
@@ -78,18 +86,21 @@ class InteresseAdocaoServiceTest {
     void deveLancarExcecaoAoManifestarInteresseComUsuarioInexistente() {
         when(usuarioRepo.findById(99L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(99L, 1L, "mensagem"))
-                .isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(99L, request))
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Usuário não encontrado: 99");
     }
 
     @Test
     void deveLancarExcecaoAoManifestarInteresseComPetInexistente() {
+        RegistrarInteresseRequest requestComPetInexistente = new RegistrarInteresseRequest(
+                99L, "mensagem", "12345678901", 25, "Quero um companheiro"
+        );
         when(usuarioRepo.findById(1L)).thenReturn(Optional.of(usuario));
         when(petRepo.findById(99L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, 99L, "mensagem"))
-                .isInstanceOf(IllegalArgumentException.class)
+        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, requestComPetInexistente))
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Pet não encontrado: 99");
     }
 
@@ -100,7 +111,7 @@ class InteresseAdocaoServiceTest {
         when(usuarioRepo.findById(1L)).thenReturn(Optional.of(usuario));
         when(petRepo.findById(1L)).thenReturn(Optional.of(pet));
 
-        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, 1L, "mensagem"))
+        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, request))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Pet não está disponível para adoção");
     }
@@ -111,7 +122,7 @@ class InteresseAdocaoServiceTest {
         when(petRepo.findById(1L)).thenReturn(Optional.of(pet));
         when(interesseRepo.existsByUsuarioAndPet(usuario, pet)).thenReturn(true);
 
-        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, 1L, "mensagem"))
+        assertThatThrownBy(() -> interesseAdocaoService.manifestarInteresse(1L, request))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Você já manifestou interesse neste pet");
     }
@@ -134,7 +145,7 @@ class InteresseAdocaoServiceTest {
         when(interesseRepo.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> interesseAdocaoService.atualizarStatus(99L, StatusInteresse.APROVADO))
-                .isInstanceOf(IllegalArgumentException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Interesse não encontrado: 99");
     }
 

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/PedidoServiceTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/PedidoServiceTest.java
@@ -1,0 +1,154 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.*;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.*;
+import com.Mybuddy.Myb.Repository.jpa.PedidoRepository;
+import com.Mybuddy.Myb.Repository.jpa.PetshopRepository;
+import com.Mybuddy.Myb.Repository.jpa.ProdutoRepository;
+import com.Mybuddy.Myb.Security.ERole;
+import com.Mybuddy.Myb.Security.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PedidoServiceTest {
+
+    @Mock
+    private PedidoRepository pedidoRepository;
+
+    @Mock
+    private ProdutoRepository produtoRepository;
+
+    @Mock
+    private PetshopRepository petshopRepository;
+
+    @InjectMocks
+    private PedidoService pedidoService;
+
+    private PedidoRequestDTO requestDTO;
+    private Usuario usuario;
+    private Petshop petshop;
+    private Produto produto;
+    private Pedido pedido;
+
+    @BeforeEach
+    void setUp() {
+        EnderecoEntregaDTO enderecoDTO = new EnderecoEntregaDTO("87000-000", "Rua Teste", "123", "Ap 1", "Bairro", "Maringá", "PR");
+        ItemPedidoRequestDTO itemDTO = new ItemPedidoRequestDTO(20L, 2);
+        requestDTO = new PedidoRequestDTO(10L, enderecoDTO, List.of(itemDTO));
+
+        usuario = new Usuario();
+        usuario.setId(1L);
+        usuario.setPetshopId(10L);
+
+        petshop = Petshop.builder()
+                .id(10L)
+                .nomeFantasia("Petshop Ed")
+                .build();
+
+        produto = new Produto();
+        produto.setId(20L);
+        produto.setNome("Ração");
+        produto.setPreco(new BigDecimal("100.00"));
+        produto.setEstoque(5);
+        produto.setStatus(StatusProduto.ATIVO);
+        produto.setPetshop(petshop);
+
+        pedido = new Pedido();
+        pedido.setId(30L);
+        pedido.setClienteId(1L);
+        pedido.setPetshop(petshop);
+        pedido.setStatus(StatusPedido.PENDENTE);
+        pedido.setEnderecoEntrega(EnderecoEntrega.builder().cep("87000-000").build());
+
+        ItemPedido item = new ItemPedido();
+        item.setId(40L);
+        item.setProduto(produto);
+        item.setQuantidade(2);
+        item.setPrecoUnitario(new BigDecimal("100.00"));
+        pedido.addItem(item);
+    }
+
+    @Test
+    void criarPedido_ComSucesso_DeveReduzirEstoque() {
+        when(petshopRepository.findById(10L)).thenReturn(Optional.of(petshop));
+        when(produtoRepository.findById(20L)).thenReturn(Optional.of(produto));
+        when(pedidoRepository.save(any(Pedido.class))).thenReturn(pedido);
+
+        PedidoResponseDTO response = pedidoService.criar(requestDTO, usuario);
+
+        assertNotNull(response);
+        assertEquals(3, produto.getEstoque()); // 5 - 2
+        verify(produtoRepository, times(1)).save(produto);
+        verify(pedidoRepository, times(1)).save(any(Pedido.class));
+    }
+
+    @Test
+    void criarPedido_EstoqueInsuficiente_DeveLancarExcecao() {
+        produto.setEstoque(1); // menor que os 2 solicitados
+
+        when(petshopRepository.findById(10L)).thenReturn(Optional.of(petshop));
+        when(produtoRepository.findById(20L)).thenReturn(Optional.of(produto));
+
+        assertThrows(IllegalArgumentException.class, () -> pedidoService.criar(requestDTO, usuario));
+        verify(pedidoRepository, never()).save(any(Pedido.class));
+    }
+
+    @Test
+    void atualizarStatus_WorkflowCorreto() {
+        Role petshopRole = new Role();
+        petshopRole.setName(ERole.ROLE_PETSHOP);
+        usuario.setRoles(Set.of(petshopRole));
+
+        when(pedidoRepository.findById(30L)).thenReturn(Optional.of(pedido));
+        when(pedidoRepository.save(any(Pedido.class))).thenReturn(pedido);
+
+        PedidoResponseDTO response = pedidoService.atualizarStatus(30L, StatusPedido.PAGO, usuario);
+
+        assertNotNull(response);
+        assertEquals(StatusPedido.PAGO.name(), response.getStatus());
+    }
+
+    @Test
+    void atualizarStatus_WorkflowIncorreto_DeveLancarExcecao() {
+        Role petshopRole = new Role();
+        petshopRole.setName(ERole.ROLE_PETSHOP);
+        usuario.setRoles(Set.of(petshopRole));
+
+        when(pedidoRepository.findById(30L)).thenReturn(Optional.of(pedido));
+
+        // Transição inválida: PENDENTE para ENTREGUE direto
+        assertThrows(IllegalArgumentException.class, () -> pedidoService.atualizarStatus(30L, StatusPedido.ENTREGUE, usuario));
+    }
+
+    @Test
+    void cancelarPedido_DevolveEstoque_PendenteParaCancelado() {
+        when(pedidoRepository.findById(30L)).thenReturn(Optional.of(pedido));
+        when(pedidoRepository.save(any(Pedido.class))).thenReturn(pedido);
+
+        int estoqueAntes = produto.getEstoque();
+
+        PedidoResponseDTO response = pedidoService.cancelar(30L, usuario);
+
+        assertNotNull(response);
+        assertEquals(StatusPedido.CANCELADO.name(), response.getStatus());
+        assertEquals(estoqueAntes + 2, produto.getEstoque()); // devolveu 2 itens
+        verify(produtoRepository, times(1)).save(produto);
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/PetServiceTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/PetServiceTest.java
@@ -7,6 +7,7 @@ import com.Mybuddy.Myb.Model.Pet;
 import com.Mybuddy.Myb.Model.StatusAdocao;
 import com.Mybuddy.Myb.Repository.mongo.InteresseAdocaoRepository;
 import com.Mybuddy.Myb.Repository.mongo.OrganizacaoRepository;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
 import com.Mybuddy.Myb.Repository.mongo.PetRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -189,7 +190,7 @@ class PetServiceTest {
         when(petRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> petService.atualizarPet(99L, petRequestDTO))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Pet com ID 99 não encontrado");
     }
 
@@ -237,7 +238,7 @@ class PetServiceTest {
         when(petRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> petService.deletarPet(99L))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessageContaining("Pet com ID 99 não encontrado");
     }
 

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/PetshopServiceTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/PetshopServiceTest.java
@@ -1,0 +1,141 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.PetshopRequestDTO;
+import com.Mybuddy.Myb.DTO.PetshopResponseDTO;
+import com.Mybuddy.Myb.Exception.ConflictException;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.Petshop;
+import com.Mybuddy.Myb.Model.Usuario;
+import com.Mybuddy.Myb.Repository.jpa.PetshopRepository;
+import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
+import com.Mybuddy.Myb.Security.ERole;
+import com.Mybuddy.Myb.Security.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PetshopServiceTest {
+
+    @Mock
+    private PetshopRepository petshopRepository;
+
+    @Mock
+    private UsuarioRepository usuarioRepository;
+
+    @InjectMocks
+    private PetshopService petshopService;
+
+    private PetshopRequestDTO requestDTO;
+    private Usuario usuario;
+    private Petshop petshop;
+
+    @BeforeEach
+    void setUp() {
+        requestDTO = new PetshopRequestDTO("Petshop do Ed", "ed@petshop.com", "12345678901234", "4499999999", "Av Principal", "Descrição legal", "www.edpet.com");
+        usuario = new Usuario("Eder", "eder@gmail.com", "4499999999", "password");
+        usuario.setId(1L);
+
+        petshop = Petshop.builder()
+                .id(10L)
+                .nomeFantasia(requestDTO.getNomeFantasia())
+                .emailContato(requestDTO.getEmailContato())
+                .cnpj(requestDTO.getCnpj())
+                .telefoneContato(requestDTO.getTelefoneContato())
+                .endereco(requestDTO.getEndereco())
+                .descricao(requestDTO.getDescricao())
+                .website(requestDTO.getWebsite())
+                .build();
+    }
+
+    @Test
+    void criarPetshop_ComSucesso() {
+        when(petshopRepository.existsByCnpj(requestDTO.getCnpj())).thenReturn(false);
+        when(petshopRepository.save(any(Petshop.class))).thenReturn(petshop);
+
+        PetshopResponseDTO response = petshopService.criar(requestDTO, usuario);
+
+        assertNotNull(response);
+        assertEquals(10L, response.getId());
+        assertEquals(10L, usuario.getPetshopId());
+        verify(usuarioRepository, times(1)).save(usuario);
+    }
+
+    @Test
+    void criarPetshop_CnpjDuplicado_DeveLancarExcecao() {
+        when(petshopRepository.existsByCnpj(requestDTO.getCnpj())).thenReturn(true);
+
+        assertThrows(ConflictException.class, () -> petshopService.criar(requestDTO, usuario));
+        verify(petshopRepository, never()).save(any(Petshop.class));
+    }
+
+    @Test
+    void buscarPorId_ComSucesso() {
+        when(petshopRepository.findById(10L)).thenReturn(Optional.of(petshop));
+
+        PetshopResponseDTO response = petshopService.buscarPorId(10L);
+
+        assertNotNull(response);
+        assertEquals(10L, response.getId());
+    }
+
+    @Test
+    void buscarPorId_Inexistente_DeveLancarExcecao() {
+        when(petshopRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> petshopService.buscarPorId(99L));
+    }
+
+    @Test
+    void atualizarPetshop_ComSucesso() {
+        Role petshopRole = new Role();
+        petshopRole.setName(ERole.ROLE_PETSHOP);
+        usuario.setRoles(Set.of(petshopRole));
+        usuario.setPetshopId(10L);
+
+        when(petshopRepository.findById(10L)).thenReturn(Optional.of(petshop));
+        when(petshopRepository.save(any(Petshop.class))).thenReturn(petshop);
+
+        PetshopResponseDTO response = petshopService.atualizar(10L, requestDTO, usuario);
+
+        assertNotNull(response);
+        verify(petshopRepository, times(1)).save(any(Petshop.class));
+    }
+
+    @Test
+    void atualizarPetshop_SemPermissao_DeveLancarExcecao() {
+        Role petshopRole = new Role();
+        petshopRole.setName(ERole.ROLE_PETSHOP);
+        usuario.setRoles(Set.of(petshopRole));
+        usuario.setPetshopId(99L); // outro petshop
+
+        when(petshopRepository.findById(10L)).thenReturn(Optional.of(petshop));
+
+        assertThrows(AuthorizationDeniedException.class, () -> petshopService.atualizar(10L, requestDTO, usuario));
+    }
+
+    @Test
+    void deletarPetshop_ComSucesso() {
+        when(petshopRepository.findById(10L)).thenReturn(Optional.of(petshop));
+        when(usuarioRepository.findByPetshopId(10L)).thenReturn(Collections.singletonList(usuario));
+
+        petshopService.deletar(10L);
+
+        assertNull(usuario.getPetshopId());
+        verify(usuarioRepository, times(1)).save(usuario);
+        verify(petshopRepository, times(1)).delete(petshop);
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/ProdutoServiceTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/ProdutoServiceTest.java
@@ -1,0 +1,158 @@
+package com.Mybuddy.Myb.Service;
+
+import com.Mybuddy.Myb.DTO.ProdutoRequestDTO;
+import com.Mybuddy.Myb.DTO.ProdutoResponseDTO;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
+import com.Mybuddy.Myb.Model.*;
+import com.Mybuddy.Myb.Repository.jpa.FotoProdutoRepository;
+import com.Mybuddy.Myb.Repository.jpa.PetshopRepository;
+import com.Mybuddy.Myb.Repository.jpa.ProdutoRepository;
+import com.Mybuddy.Myb.Repository.jpa.SubCategoriaRepository;
+import com.Mybuddy.Myb.Security.ERole;
+import com.Mybuddy.Myb.Security.Role;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authorization.AuthorizationDeniedException;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ProdutoServiceTest {
+
+    @Mock
+    private ProdutoRepository produtoRepository;
+
+    @Mock
+    private SubCategoriaRepository subCategoriaRepository;
+
+    @Mock
+    private PetshopRepository petshopRepository;
+
+    @Mock
+    private FotoProdutoRepository fotoProdutoRepository;
+
+    @InjectMocks
+    private ProdutoService produtoService;
+
+    private ProdutoRequestDTO requestDTO;
+    private Usuario usuario;
+    private Petshop petshop;
+    private SubCategoria subCategoria;
+    private Categoria categoria;
+    private Produto produto;
+
+    @BeforeEach
+    void setUp() {
+        requestDTO = new ProdutoRequestDTO("Ração Premier", "Ração super premium", new BigDecimal("150.00"), 10, 1L, List.of("url1", "url2"));
+        
+        usuario = new Usuario();
+        usuario.setId(1L);
+        usuario.setPetshopId(10L);
+
+        petshop = Petshop.builder()
+                .id(10L)
+                .nomeFantasia("Petshop Ed")
+                .build();
+
+        categoria = Categoria.builder().id(5L).nome("Cães").build();
+        subCategoria = SubCategoria.builder().id(1L).nome("Ração").categoria(categoria).build();
+
+        produto = new Produto();
+        produto.setId(20L);
+        produto.setNome("Ração Premier");
+        produto.setDescricao("Ração super premium");
+        produto.setPreco(new BigDecimal("150.00"));
+        produto.setEstoque(10);
+        produto.setSubCategoria(subCategoria);
+        produto.setPetshop(petshop);
+        produto.setStatus(StatusProduto.ATIVO);
+    }
+
+    @Test
+    void criarProduto_ComSucesso() {
+        when(petshopRepository.findById(10L)).thenReturn(Optional.of(petshop));
+        when(subCategoriaRepository.findById(1L)).thenReturn(Optional.of(subCategoria));
+        when(produtoRepository.save(any(Produto.class))).thenReturn(produto);
+
+        ProdutoResponseDTO response = produtoService.criar(requestDTO, usuario);
+
+        assertNotNull(response);
+        assertEquals(20L, response.getId());
+        assertEquals("Ração Premier", response.getNome());
+        verify(produtoRepository, times(1)).save(any(Produto.class));
+    }
+
+    @Test
+    void criarProduto_SemPetshopCadastrado_DeveLancarExcecao() {
+        usuario.setPetshopId(null);
+
+        assertThrows(IllegalArgumentException.class, () -> produtoService.criar(requestDTO, usuario));
+    }
+
+    @Test
+    void buscarProdutoPorId_ComSucesso() {
+        when(produtoRepository.findById(20L)).thenReturn(Optional.of(produto));
+
+        ProdutoResponseDTO response = produtoService.buscarPorIdDTO(20L);
+
+        assertNotNull(response);
+        assertEquals(20L, response.getId());
+    }
+
+    @Test
+    void buscarProdutoPorId_Inexistente_DeveLancarExcecao() {
+        when(produtoRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> produtoService.buscarPorIdDTO(99L));
+    }
+
+    @Test
+    void atualizarProduto_ComSucesso() {
+        Role petshopRole = new Role();
+        petshopRole.setName(ERole.ROLE_PETSHOP);
+        usuario.setRoles(Set.of(petshopRole));
+
+        when(produtoRepository.findById(20L)).thenReturn(Optional.of(produto));
+        when(subCategoriaRepository.findById(1L)).thenReturn(Optional.of(subCategoria));
+        when(produtoRepository.save(any(Produto.class))).thenReturn(produto);
+
+        ProdutoResponseDTO response = produtoService.atualizar(20L, requestDTO, usuario);
+
+        assertNotNull(response);
+        verify(produtoRepository, times(1)).save(any(Produto.class));
+    }
+
+    @Test
+    void atualizarProduto_SemPermissao_DeveLancarExcecao() {
+        Role petshopRole = new Role();
+        petshopRole.setName(ERole.ROLE_PETSHOP);
+        usuario.setRoles(Set.of(petshopRole));
+        usuario.setPetshopId(99L); // outro petshop
+
+        when(produtoRepository.findById(20L)).thenReturn(Optional.of(produto));
+
+        assertThrows(AuthorizationDeniedException.class, () -> produtoService.atualizar(20L, requestDTO, usuario));
+    }
+
+    @Test
+    void deletarProduto_ComSucesso() {
+        Role adminRole = new Role();
+        adminRole.setName(ERole.ROLE_ADMIN);
+        usuario.setRoles(Set.of(adminRole));
+
+        when(produtoRepository.findById(20L)).thenReturn(Optional.of(produto));
+
+        produtoService.deletar(20L, usuario);
+
+        verify(produtoRepository, times(1)).delete(produto);
+    }
+}

--- a/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/UsuarioServiceTest.java
+++ b/Back End/JavaSpring/Myb Def/backend-mybuddy/src/test/java/com/Mybuddy/Myb/Service/UsuarioServiceTest.java
@@ -1,5 +1,7 @@
 package com.Mybuddy.Myb.Service;
 
+import com.Mybuddy.Myb.Exception.ConflictException;
+import com.Mybuddy.Myb.Exception.ResourceNotFoundException;
 import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Repository.mongo.UsuarioRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +60,7 @@ class UsuarioServiceTest {
 
         // Act & Assert
         assertThatThrownBy(() -> usuarioService.criarUsuario(usuario))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ConflictException.class)
                 .hasMessage("O e-mail informado já está em uso.");
 
         verify(usuarioRepository, never()).save(any());
@@ -129,7 +131,7 @@ class UsuarioServiceTest {
 
         // Act & Assert
         assertThatThrownBy(() -> usuarioService.atualizarUsuario(99L, usuario))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("Usuário com ID 99 não encontrado.");
     }
 
@@ -154,7 +156,7 @@ class UsuarioServiceTest {
 
         // Act & Assert
         assertThatThrownBy(() -> usuarioService.deletarUsuario(99L))
-                .isInstanceOf(IllegalStateException.class)
+                .isInstanceOf(ResourceNotFoundException.class)
                 .hasMessage("Usuário com ID 99 não encontrado.");
 
         verify(usuarioRepository, never()).deleteById(any());


### PR DESCRIPTION
## Task Jira

> Vincule a task relacionada a este PR

- **Card:** [MYB-32](https://mybuddy.atlassian.net/browse/MYB-32)
- **Tipo:** Feature | Refactor

---

## O que foi feito?

> Descreva de forma objetiva o que este PR implementa ou resolve.

- **CRUD do Marketplace:** Implementação completa das entidades relacionais (`Categoria`, `SubCategoria`, `Produto`, `Pedido`, `EnderecoEntrega` e `AvaliacaoProduto`) no PostgreSQL e exposição dos respectivos endpoints de controle de estoque, compras, avaliações de produtos e transições de status de pedidos.
- **Refatorações e Otimizações Gerais:** Padronização da injeção de dependências nas classes de Serviço e Controladores usando a anotação `@RequiredArgsConstructor` do Lombok. Centralização do tratamento de erros através do `GlobalExceptionHandler` utilizando exceções semânticas de negócio (`ResourceNotFoundException`, `ConflictException`) para retornar payloads JSON padronizados.
- **Correção de Erros de Teste e Limpeza de Warnings:**
  * Corrigida a falha de compilação em `PetControllerTest.java` adicionando o novo parâmetro `descricao` ao instanciar o mock `PetResponse`.
  * Removidos imports não utilizados (ex: `CampanhaDoacao` em `PaymentService.java`) e adicionados `@SuppressWarnings("null")` para limpar os avisos de segurança de tipo nulo na IDE (`PaymentService`, `MybApplication`, `DataInitializer`, `MercadoPagoWebhookValidator`).
- **Descrição do Pet:** Inclusão do campo de biografia/história (`descricao`) na entidade `Pet` e nos seus DTOs de request e response.
- **Formulário de Interesse de Adoção:** Expansão do fluxo de manifestação de interesse para coletar e validar dados estruturados do adotante (`cpfAdotante`, `idadeAdotante` - mínimo de 18 anos e `motivoAdocao`), omitindo os campos de residência, outros pets, tempo sozinho e proteção de janelas conforme regras solicitadas.

---

## Escopo das mudanças

> Marque os módulos afetados por este PR

- [x] `backend` — Java / Spring Boot
- [ ] `frontend` — Angular
- [ ] `mobile` — Flutter
- [ ] `infra` — Docker / CI / configurações

---

## Checklist de Testes

> Confirme que os cenários abaixo foram validados antes de abrir o PR

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [x] Testes automatizados foram criados ou atualizados (se aplicável)

---

## Checklist de Code Review

> Para o **autor** preencher antes de solicitar revisão

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [x] Migrations de banco (se houver) foram testadas e são reversíveis

---

## Notas para o Revisor

> Algum ponto de atenção, decisão técnica ou contexto que o revisor deve saber?

- As regras de injeção de dependências foram todas modernizadas para o padrão constructor-based do Lombok, deixando os arquivos mais limpos e fáceis de testar.
- Os testes unitários que utilizam mocks (`@ExtendWith(MockitoExtension.class)`) foram todos atualizados para acomodar a nova assinatura DTO do formulário de adoção e estão com 100% de sucesso.
- Os avisos de análise de tipo nulo (Null type safety) do compilador Eclipse JDT no VS Code foram silenciados utilizando `@SuppressWarnings("null")` nas principais classes que interagem com Spring Data para que o painel de erros da IDE fique limpo.

---

## Como testar

> Passo a passo para o revisor reproduzir e validar as mudanças

1. Certifique-se de compilar e rodar os testes unitários do backend para validar a integridade dos serviços e controladores:
   ```bash
   ./mvnw.cmd test "-Dtest=PetServiceTest,InteresseAdocaoServiceTest,PetControllerTest,UsuarioServiceTest"
