### PR TITLE
fix(backend): restringe DataInitializer ao profile dev [MY-398] #done

### DIFF
--- a/backend/src/main/java/com/Mybuddy/Myb/Util/DataInitializer.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Util/DataInitializer.java
@@ -14,9 +14,17 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.math.BigDecimal;
 import java.util.HashSet;
 import java.util.Set;
+import org.springframework.context.annotation.Profile;
 
+/**
+ * Seed de dados para ambiente de desenvolvimento.
+ * NÃO é executado em produção (profile docker/prod).
+ * Usuários criados aqui usam senha local "Senha123" — 
+ * em produção a autenticação é exclusivamente via Keycloak.
+ */
 
 @Configuration
+@Profile("dev")
 @RequiredArgsConstructor
 @SuppressWarnings("null")
 public class DataInitializer {
@@ -186,7 +194,6 @@ public class DataInitializer {
             log.info("Garantindo Pets reais no banco de dados...");
             if (petRepository.findByNome("Zeus").isEmpty()) {
                 Pet p1 = new Pet("Zeus", "SRD", 2, Especie.CAO, Porte.MEDIO, "Marrom", "Curta", "Macho", myBuddyOrg, true, true, true, "São Paulo", "SP");
-                p1.setId(1L);
                 p1.setDescricao("Zeus é um cãozinho muito alegre, dócil e companheiro. Adora correr em espaços abertos e se dá muito bem com outros cachorros.");
                 FotoPet f1 = new FotoPet();
                 f1.setUrl("https://images.unsplash.com/photo-1543466835-00a7907e9de1?auto=format&fit=crop&q=80&w=600");
@@ -197,7 +204,6 @@ public class DataInitializer {
             }
             if (petRepository.findByNome("Mia").isEmpty()) {
                 Pet p2 = new Pet("Mia", "Persa", 1, Especie.GATO, Porte.PEQUENO, "Branco", "Longa", "Fêmea", myBuddyOrg, true, true, false, "São Paulo", "SP");
-                p2.setId(2L);
                 p2.setDescricao("Mia é uma gatinha calma, carinhosa e muito dorminhoca. Perfeita para apartamentos. Gosta de ser escovada e receber carinho.");
                 FotoPet f2 = new FotoPet();
                 f2.setUrl("https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?auto=format&fit=crop&q=80&w=600");
@@ -208,7 +214,6 @@ public class DataInitializer {
             }
             if (petRepository.findByNome("Thor").isEmpty()) {
                 Pet p3 = new Pet("Thor", "Golden Retriever", 1, Especie.CAO, Porte.GRANDE, "Dourado", "Longa", "Macho", myBuddyOrg, true, true, true, "São Paulo", "SP");
-                p3.setId(3L);
                 p3.setDescricao("Thor é um Golden Retriever brincalhão, inteligente e cheio de energia. Ideal para famílias ativas que adoram passear.");
                 FotoPet f3 = new FotoPet();
                 f3.setUrl("https://images.unsplash.com/photo-1552053831-71594a27632d?auto=format&fit=crop&q=80&w=600");

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=Myb
 server.port=8081
+spring.profiles.activate=dev
 
 #Keycloak
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080/realms/mybuddy
@@ -57,4 +58,4 @@ mercadopago.webhook-secret=${MERCADOPAGO_WEBHOOK_SECRET:webhook-placeholder}
 # ── Redis (Cache & Session) ──
 spring.data.redis.host=${SPRING_REDIS_HOST:localhost}
 spring.data.redis.port=${SPRING_REDIS_PORT:6379}
-spring.cache.type=redis
+spring.cache.type=redis


### PR DESCRIPTION
## Task Jira

- **Card:** [[MY-398](https://ederpontes2014.atlassian.net/browse/MY-398)](https://ederpontes2014.atlassian.net/browse/MY-398)
- **Tipo:** Fix

---

## O que foi feito?

Restringe o `DataInitializer` para executar apenas no profile `dev`, impedindo que dados fictícios (usuários teste, ONG, pets, produtos, petshop) sejam inseridos em produção. Também corrige IDs hardcoded que conflitavam com a geração automática do PostgreSQL e adiciona documentação sobre o propósito do seed.

---

## Escopo das mudanças

- [x] `backend` — Java / Spring Boot
- [ ] `frontend` — Angular
- [ ] `mobile` — Flutter
- [ ] `infra` — Docker / CI / configurações

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [ ] Testes automatizados foram criados ou atualizados (se aplicável)

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e são reversíveis

---

## Notas para o Revisor

O `DataInitializer` não foi deletado, apenas condicionado com `@Profile("dev")`. Isso mantém o seed funcional para desenvolvimento local sem afetar o ambiente de produção (profile `docker`). Os `setId()` forçados nos pets foram removidos porque conflitavam com `BIGSERIAL` — o Postgres gera os IDs automaticamente. Usuários seed continuam com senha "Senha123" para conveniência no dev, mas em produção a autenticação é exclusivamente via Keycloak.

---

## Como testar

```
1. Subir o compose com SPRING_PROFILES_ACTIVE=docker
2. Verificar nos logs que "Iniciando inicialização de dados..." NÃO aparece
3. Confirmar que as tabelas estão vazias (sem Zeus, Mia, Thor, etc)
4. Subir com SPRING_PROFILES_ACTIVE=dev e confirmar que o seed executa normalmente
```

[MY-398]: https://ederpontes2014.atlassian.net/browse/MY-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ