### PR TITLE
fix(backend): remove h2-console e frameOptions do SecurityConfig [MY-…

### DIFF
--- a/backend/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
@@ -38,7 +38,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/uploads/**").permitAll()
-                        .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/api/payments/preference/**").permitAll()
@@ -47,8 +46,6 @@ public class SecurityConfig {
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/categorias/**").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/petshop/**").permitAll()
                         .anyRequest().authenticated())
-                .headers(headers -> headers
-                        .frameOptions(frame -> frame.sameOrigin()))
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter)));
 


### PR DESCRIPTION
## Task Jira

- **Card:** [[MY-401](https://ederpontes2014.atlassian.net/browse/MY-401)](https://ederpontes2014.atlassian.net/browse/MY-401)
- **Tipo:** Fix

---

## O que foi feito?

Remove endpoints de debug do `SecurityConfig` que não devem existir em produção: permissão aberta para `/h2-console/**` (banco é PostgreSQL, H2 não é utilizado) e configuração `frameOptions.sameOrigin` que existia exclusivamente para o H2 Console funcionar em iframe.

---

## Escopo das mudanças

- [x] `backend` — Java / Spring Boot
- [ ] `frontend` — Angular
- [ ] `mobile` — Flutter
- [ ] `infra` — Docker / CI / configurações

---

## Arquivos alterados

### Modificados
- `backend/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java`
  - Removido `.requestMatchers("/h2-console/**").permitAll()` — endpoint de debug de banco H2 que não é utilizado (banco é PostgreSQL)
  - Removido `.headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))` — configuração que existia exclusivamente para permitir o H2 Console rodar em iframe

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [ ] Testes automatizados foram criados ou atualizados (se aplicável)

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e são reversíveis

---

## Notas para o Revisor

O Swagger (`/swagger-ui/**`, `/v3/api-docs/**`) foi mantido aberto intencionalmente para facilitar testes e a apresentação do TCC. Em um cenário real de produção, deveria ser protegido ou condicionado ao profile.

A remoção do `frameOptions.sameOrigin` não afeta nenhuma funcionalidade do sistema — era configuração exclusiva do H2 Console. O comportamento padrão do Spring Security (`DENY`) é mais seguro e previne ataques de clickjacking.

---

## Como testar

```
1. mvn clean compile — confirmar que compila sem erros
2. Subir o backend com docker compose up -d
3. Acessar /h2-console → deve retornar 403 Forbidden (antes retornava a interface do H2)
4. Acessar /swagger-ui/index.html → deve continuar funcionando normalmente
5. Acessar /actuator/health → deve continuar retornando status UP
6. Login e operações CRUD devem funcionar normalmente
```

[MY-401]: https://ederpontes2014.atlassian.net/browse/MY-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ