### PR TITLE
feat(frontend): configura environment com placeholders para produção …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,11 @@ services:
 
     networks:
       - mybuddy-network
+    
+    environment:
+      KEYCLOAK_URL: ${KEYCLOAK_URL:-http://localhost:8080}
+      PUBLIC_URL: ${PUBLIC_URL:-http://localhost}
+      MP_PUBLIC_KEY: ${MP_PUBLIC_KEY:-APP_USR-112696f3-3603-4175-826f-167cf58606b2}
 
 # ── MY-243: Declaração dos volumes ───────────────────────────
 # Dados salvos mesmo após "docker compose down"

--- a/frontend/docker-entrypoint.sh
+++ b/frontend/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+find /usr/share/nginx/html -name '*.js' -exec sed -i \
+  -e "s|__KEYCLOAK_URL__|${KEYCLOAK_URL:-http://localhost:8080}|g" \
+  -e "s|__PUBLIC_URL__|${PUBLIC_URL:-http://localhost}|g" \
+  -e "s|__MP_PUBLIC_KEY__|${MP_PUBLIC_KEY:-APP_USR-112696f3-3603-4175-826f-167cf58606b2}|g" \
+  {} +
+
+exec nginx -g 'daemon off;'

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -29,4 +29,6 @@ COPY --from=builder /app/dist/mybuddy/browser /usr/share/nginx/html
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/frontend/src/environments/environment.ts
+++ b/frontend/src/environments/environment.ts
@@ -1,13 +1,12 @@
 export const environment = {
   production: true,
-  apiUrl: "/api/",
-  envName: "production",
-  
-  mercadoPagoPublicKey: "APP_USR-112696f3-3603-4175-826f-167cf58606b2",
+  apiUrl: '/api/',
+  envName: 'production',
+  mercadoPagoPublicKey: '__MP_PUBLIC_KEY__',
   keycloak: {
-    url: "http://localhost:8080",
-    realm: "mybuddy",
-    clientId: "mybuddy-frontend",
-    silentCheckSsoRedirectUri: "http://localhost/silent-check-sso.html",
+    url: '__KEYCLOAK_URL__',
+    realm: 'mybuddy',
+    clientId: 'mybuddy-frontend',
+    silentCheckSsoRedirectUri: '__PUBLIC_URL__/silent-check-sso.html',
   },
 };


### PR DESCRIPTION
## Task Jira

- **Card:** [[MY-403](https://ederpontes2014.atlassian.net/browse/MY-403)](https://ederpontes2014.atlassian.net/browse/MY-403)
- **Tipo:** Feature

---

## O que foi feito?

Configura o `environment.ts` de produção do Angular com placeholders que são substituídos em runtime pelo `docker-entrypoint.sh` do container Nginx. Isso permite que o mesmo build do frontend funcione em qualquer ambiente (dev, staging, produção) apenas trocando as variáveis de ambiente do Docker, sem precisar recompilar.

---

## Escopo das mudanças

- [ ] `backend` — Java / Spring Boot
- [x] `frontend` — Angular
- [ ] `mobile` — Flutter
- [x] `infra` — Docker / CI / configurações

---

## Arquivos alterados

### Modificados
- **`frontend/src/environments/environment.ts`** — URLs e chaves substituídas por placeholders: `__KEYCLOAK_URL__`, `__PUBLIC_URL__`, `__MP_PUBLIC_KEY__`
- **`frontend/dockerfile`** — Substituído `CMD` por `ENTRYPOINT` apontando para `docker-entrypoint.sh`
- **`docker-compose.yml`** — Adicionadas env vars `KEYCLOAK_URL`, `PUBLIC_URL`, `MP_PUBLIC_KEY` no service frontend

### Adicionados
- **`frontend/docker-entrypoint.sh`** — Script que executa `sed` nos arquivos `.js` compilados antes de iniciar o Nginx, substituindo placeholders pelos valores reais das env vars. Fallbacks: `KEYCLOAK_URL` → `http://localhost:8080`, `PUBLIC_URL` → `http://localhost`, `MP_PUBLIC_KEY` → chave sandbox do Mercado Pago
- **`env.production.example`** — Template completo com todas as variáveis necessárias para deploy em produção (PostgreSQL, MongoDB, Keycloak, Backend, Mercado Pago, URLs públicas)

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [ ] Testes automatizados foram criados ou atualizados (se aplicável)

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e são reversíveis

---

## Notas para o Revisor

A abordagem de substituição via `sed` nos JS compilados é a mais simples para injetar configuração em runtime num frontend Angular. Alternativas como `APP_INITIALIZER` com fetch a um `/config.json` são mais elegantes mas adicionam complexidade e um round-trip extra no carregamento.

Os fallbacks no `docker-entrypoint.sh` garantem que o `docker compose up` local continua funcionando sem definir nenhuma env var — os valores default apontam para localhost e chave sandbox do Mercado Pago.

O `env.production.example` **não contém nenhuma senha real** — apenas placeholders com instruções de geração. O `.env` real com credenciais de produção deve ser criado diretamente na VM da GCE e nunca commitado.

O `environment.development.ts` não foi alterado — continua com valores fixos para localhost, já que em dev não roda via Docker.

---

## Como testar

```
1. docker compose build frontend
2. docker compose up -d frontend
3. Acessar localhost e abrir DevTools → Sources → buscar nos JS por "__KEYCLOAK_URL__"
   → NÃO deve aparecer (foi substituído por http://localhost:8080)
4. Buscar por "__MP_PUBLIC_KEY__"
   → NÃO deve aparecer (foi substituído pela chave sandbox)
5. Parar o container, setar KEYCLOAK_URL=https://teste.com no .env
6. docker compose up -d frontend
7. Buscar nos JS → deve aparecer https://teste.com em vez de localhost
```

[MY-403]: https://ederpontes2014.atlassian.net/browse/MY-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ