### PR TITLE
feat(frontend): melhora nginx.conf com segurança e cache otimizado [M…

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,20 +1,26 @@
 server {
     listen 80;
-    server_name localhost;
+    server_name _;
 
     root /usr/share/nginx/html;
     index index.html;
 
+    # Compressão
     gzip on;
-    gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+    gzip_min_length 256;
+
+    # Headers de segurança
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     # SPA: qualquer rota que não existir como arquivo serve o index.html
-    # Isso faz o roteamento do Angular funcionar no F5
     location / {
         try_files $uri $uri/ /index.html;
     }
 
-    # Proxy reverso: /api/* vai para o backend na porta 8081
+    # Proxy reverso: /api/* vai para o backend (usado em dev Docker, Caddy intercepta em produção)
     location /api/ {
         proxy_pass http://backend:8081;
         proxy_set_header Host $host;
@@ -23,9 +29,17 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Cache para arquivos estáticos gerados pelo Angular
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
+    # Cache para arquivos estáticos (hash no filename pelo Angular)
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        access_log off;
+    }
+
+    # Bloqueia acesso a dotfiles
+    location ~ /\. {
+        deny all;
+        access_log off;
+        log_not_found off;
     }
 }


### PR DESCRIPTION
## Task Jira

- **Card:** [[MY-406](https://ederpontes2014.atlassian.net/browse/MY-406)](https://ederpontes2014.atlassian.net/browse/MY-406)
- **Tipo:** Feature

---

## O que foi feito?

Melhora a configuração do Nginx do frontend para produção com headers de segurança, cache otimizado, compressão expandida e bloqueio de dotfiles. O proxy reverso para `/api/` foi mantido para compatibilidade com dev Docker (em produção o Caddy intercepta antes).

---

## Escopo das mudanças

- [ ] `backend` — Java / Spring Boot
- [x] `frontend` — Angular
- [ ] `mobile` — Flutter
- [x] `infra` — Docker / CI / configurações

---

## Arquivos alterados

### Modificados
- **`frontend/nginx.conf`**
  - `server_name` de `localhost` para `_` (aceita qualquer hostname, necessário atrás do Caddy)
  - Adicionados headers de segurança: `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: strict-origin-when-cross-origin`
  - Gzip expandido: adicionados `application/xml+rss`, `text/javascript` e `gzip_min_length 256`
  - Cache de estáticos expandido: adicionados `ttf`, `eot` (fontes) e `access_log off` para reduzir logs
  - Adicionado bloco `location ~ /\.` que bloqueia acesso a dotfiles (`.env`, `.git`, etc)
  - Proxy `/api/` mantido com comentário explicando: usado em dev Docker, Caddy intercepta em produção

---

## Checklist de Testes

- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [ ] Testes automatizados foram criados ou atualizados (se aplicável)

---

## Checklist de Code Review

- [x] O código segue os padrões e convenções do projeto
- [x] Não há código comentado ou `TODO` esquecido sem justificativa
- [x] Variáveis, métodos e classes têm nomes claros e descritivos
- [x] Não há lógica duplicada que poderia ser extraída
- [x] Dados sensíveis não estão expostos (tokens, senhas, chaves)
- [ ] Migrations de banco (se houver) foram testadas e são reversíveis

---

## Notas para o Revisor

**Por que o proxy `/api/` foi mantido:** em dev via Docker (compose com override, sem Caddy na frente), o Angular faz requests para `/api/` relativo que bate direto no Nginx — sem o proxy, retorna 404. Em produção com Caddy, a rota `/api/*` é interceptada antes de chegar ao Nginx, então o bloco nunca é executado. Manter não causa conflito e garante compatibilidade em ambos os cenários.

**Headers de segurança:**
- `X-Content-Type-Options: nosniff` — previne MIME type sniffing
- `X-Frame-Options: DENY` — previne clickjacking (complementa a remoção do `frameOptions.sameOrigin` do SecurityConfig na MY-401)
- `Referrer-Policy: strict-origin-when-cross-origin` — controla o que é enviado no header Referer

**Dotfiles:** o bloco `location ~ /\.` retorna 403 para qualquer requisição a arquivos que comecem com ponto. Previne acesso acidental a `.env`, `.git`, `.htaccess`, etc, caso existam no diretório do build.

---

## Como testar

```
1. docker compose build frontend
2. docker compose up -d

Headers de segurança:
3. curl -I localhost → verificar X-Content-Type-Options, X-Frame-Options, Referrer-Policy nos headers

Cache:
4. curl -I localhost/main.js → verificar Cache-Control: public, immutable e Expires

Dotfiles:
5. curl localhost/.env → deve retornar 403 Forbidden
6. curl localhost/.git/config → deve retornar 403 Forbidden

SPA routing:
7. curl localhost/pets → deve retornar o index.html (não 404)

Proxy API (dev Docker):
8. curl localhost/api/actuator/health → deve retornar {"status":"UP"}
```

[MY-406]: https://ederpontes2014.atlassian.net/browse/MY-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ