### PR TITLE
Fix/myb 380 vazamento dados multi tenancy

### DIFF
--- a/backend/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Config/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/payments/webhook").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/produtos/**").permitAll()
                         .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/categorias/**").permitAll()
-                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/petshop/**").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/petshop").permitAll()
+                        .requestMatchers(org.springframework.http.HttpMethod.GET, "/api/petshop/{id}").permitAll()
                         .anyRequest().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2
                         .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter)));

--- a/backend/src/main/java/com/Mybuddy/Myb/Controller/OngController.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Controller/OngController.java
@@ -2,15 +2,15 @@ package com.Mybuddy.Myb.Controller;
 
 import com.Mybuddy.Myb.DTO.InteresseAdocaoMapper;
 import com.Mybuddy.Myb.DTO.InteresseResponse;
+import com.Mybuddy.Myb.DTO.PetResponse;
 import com.Mybuddy.Myb.Model.EventoOng;
 import com.Mybuddy.Myb.Model.InteresseAdocao;
-import com.Mybuddy.Myb.Model.Pet;
 import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Security.ERole;
 import com.Mybuddy.Myb.Repository.mongo.EventoOngRepository;
 import com.Mybuddy.Myb.Repository.mongo.InteresseAdocaoRepository;
-import com.Mybuddy.Myb.Repository.mongo.PetRepository;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
+import com.Mybuddy.Myb.Service.PetService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -28,7 +28,7 @@ public class OngController {
 
     private final InteresseAdocaoRepository interesseAdocaoRepository;
     private final EventoOngRepository eventoOngRepository;
-    private final PetRepository petRepository;
+    private final PetService petService;
     private final KeycloakUserSyncService keycloakUserSyncService;
 
     @GetMapping("/solicitacoes")
@@ -65,18 +65,18 @@ public class OngController {
 
     @GetMapping("/pets")
     @PreAuthorize("hasRole('ONG') or hasRole('ADMIN')")
-    public ResponseEntity<List<Pet>> getPets(@AuthenticationPrincipal Jwt jwt) {
+    public ResponseEntity<List<PetResponse>> getPets(@AuthenticationPrincipal Jwt jwt) {
         Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
         boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
-        
+
         if (isAdmin) {
-            return ResponseEntity.ok(petRepository.findAll());
+            return ResponseEntity.ok(petService.listarTodosDTO());
         }
-        
+
         if (usuario.getOrganizacao() == null) {
             return ResponseEntity.ok(List.of());
         }
-        
-        return ResponseEntity.ok(petRepository.findByOrganizacaoId(usuario.getOrganizacao().getId()));
+
+        return ResponseEntity.ok(petService.buscarPetsPorOrganizacaoId(usuario.getOrganizacao().getId()));
     }
 }

--- a/backend/src/main/java/com/Mybuddy/Myb/Controller/OngController.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Controller/OngController.java
@@ -1,5 +1,7 @@
 package com.Mybuddy.Myb.Controller;
 
+import com.Mybuddy.Myb.DTO.InteresseAdocaoMapper;
+import com.Mybuddy.Myb.DTO.InteresseResponse;
 import com.Mybuddy.Myb.Model.EventoOng;
 import com.Mybuddy.Myb.Model.InteresseAdocao;
 import com.Mybuddy.Myb.Model.Pet;
@@ -31,19 +33,17 @@ public class OngController {
 
     @GetMapping("/solicitacoes")
     @PreAuthorize("hasRole('ONG') or hasRole('ADMIN')")
-    public ResponseEntity<List<InteresseAdocao>> getSolicitacoes(@AuthenticationPrincipal Jwt jwt) {
+    public ResponseEntity<List<InteresseResponse>> getSolicitacoes(@AuthenticationPrincipal Jwt jwt) {
         Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
         boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
-        
-        if (isAdmin) {
-            return ResponseEntity.ok(interesseAdocaoRepository.findAll());
-        }
-        
-        if (usuario.getOrganizacao() == null) {
-            return ResponseEntity.ok(List.of());
-        }
-        
-        return ResponseEntity.ok(interesseAdocaoRepository.findByPetOrganizacaoId(usuario.getOrganizacao().getId()));
+
+        List<InteresseAdocao> entidades = isAdmin
+                ? interesseAdocaoRepository.findAll()
+                : (usuario.getOrganizacao() == null
+                        ? List.of()
+                        : interesseAdocaoRepository.findByPetOrganizacaoId(usuario.getOrganizacao().getId()));
+
+        return ResponseEntity.ok(entidades.stream().map(InteresseAdocaoMapper::toResponse).toList());
     }
 
     @GetMapping("/eventos")

--- a/backend/src/main/java/com/Mybuddy/Myb/Controller/PetshopController.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Controller/PetshopController.java
@@ -123,17 +123,17 @@ public class PetshopController {
     // ── LEGACY ENDPOINTS (Compatibilidade com Front) ──────────────────────────
 
     @GetMapping("/produtos")
-    @PreAuthorize("isAuthenticated()")
+    @PreAuthorize("hasAnyRole('PETSHOP', 'ADMIN')")
     public ResponseEntity<List<Produto>> getProdutos(@AuthenticationPrincipal Jwt jwt) {
         Usuario usuario = keycloakUserSyncService.syncUsuario(jwt);
-        boolean isPetshop = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_PETSHOP);
-        if (isPetshop) {
-            if (usuario.getPetshopId() != null) {
-                return ResponseEntity.ok(produtoRepository.findByPetshopId(usuario.getPetshopId()));
-            }
-            return ResponseEntity.ok(List.of());
+        boolean isAdmin = usuario.getRoles().stream().anyMatch(r -> r.getName() == ERole.ROLE_ADMIN);
+        if (isAdmin) {
+            return ResponseEntity.ok(produtoRepository.findAll());
         }
-        return ResponseEntity.ok(produtoRepository.findAll());
+        if (usuario.getPetshopId() != null) {
+            return ResponseEntity.ok(produtoRepository.findByPetshopId(usuario.getPetshopId()));
+        }
+        return ResponseEntity.ok(List.of());
     }
 
     @GetMapping("/pedidos")

--- a/backend/src/main/java/com/Mybuddy/Myb/Controller/PetshopController.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Controller/PetshopController.java
@@ -1,5 +1,6 @@
 package com.Mybuddy.Myb.Controller;
 
+import com.Mybuddy.Myb.DTO.PetshopPublicResponseDTO;
 import com.Mybuddy.Myb.DTO.PetshopRequestDTO;
 import com.Mybuddy.Myb.DTO.PetshopResponseDTO;
 import com.Mybuddy.Myb.Model.Chat;
@@ -50,16 +51,16 @@ public class PetshopController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<PetshopResponseDTO> buscarPorId(@PathVariable Long id) {
+    public ResponseEntity<PetshopPublicResponseDTO> buscarPorId(@PathVariable Long id) {
         log.info("Buscando petshop por ID: {}", id);
-        return ResponseEntity.ok(petshopService.buscarPorId(id));
+        return ResponseEntity.ok(petshopService.buscarPorIdPublico(id));
     }
 
     /**
-     * Listagem pública: retorna apenas Petshops APROVADOS.
+     * Listagem pública: retorna apenas Petshops APROVADOS, sem dados sensíveis.
      */
     @GetMapping
-    public ResponseEntity<List<PetshopResponseDTO>> listarAprovados() {
+    public ResponseEntity<List<PetshopPublicResponseDTO>> listarAprovados() {
         log.info("Listagem pública de petshops aprovados.");
         return ResponseEntity.ok(petshopService.listarAprovados());
     }

--- a/backend/src/main/java/com/Mybuddy/Myb/DTO/PetshopPublicResponseDTO.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/DTO/PetshopPublicResponseDTO.java
@@ -1,0 +1,21 @@
+package com.Mybuddy.Myb.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PetshopPublicResponseDTO {
+    private Long id;
+    private String nomeFantasia;
+    private String telefoneContato;
+    private String endereco;
+    private String descricao;
+    private String website;
+    private BigDecimal valorMinimoFreteGratis;
+}

--- a/backend/src/main/java/com/Mybuddy/Myb/Service/PetService.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Service/PetService.java
@@ -247,6 +247,12 @@ public class PetService {
                 .collect(Collectors.toList());
     }
 
+    public List<PetResponse> listarTodosDTO() {
+        return petRepository.findAll().stream()
+                .map(this::toPetResponse)
+                .collect(Collectors.toList());
+    }
+
     public Page<PetResponse> buscarComFiltrosDTO(PetFiltro filtro, Pageable pageable) {
         log.debug("Buscando pets com filtros no MongoDB: {}", filtro);
         Query query = new Query();

--- a/backend/src/main/java/com/Mybuddy/Myb/Service/PetshopService.java
+++ b/backend/src/main/java/com/Mybuddy/Myb/Service/PetshopService.java
@@ -1,5 +1,6 @@
 package com.Mybuddy.Myb.Service;
 
+import com.Mybuddy.Myb.DTO.PetshopPublicResponseDTO;
 import com.Mybuddy.Myb.DTO.PetshopRequestDTO;
 import com.Mybuddy.Myb.DTO.PetshopResponseDTO;
 import com.Mybuddy.Myb.Exception.ConflictException;
@@ -75,14 +76,26 @@ public class PetshopService {
     }
 
     /**
-     * Listagem pública: exibe apenas Petshops APROVADOS.
-     * Adotantes/visitantes não veem petshops pendentes ou rejeitados.
+     * Listagem pública: exibe apenas Petshops APROVADOS, sem dados sensíveis.
      */
     @Transactional(readOnly = true)
-    public List<PetshopResponseDTO> listarAprovados() {
+    public List<PetshopPublicResponseDTO> listarAprovados() {
         return petshopRepository.findByStatusAprovacao(StatusAprovacao.APROVADO).stream()
-                .map(this::toResponseDTO)
+                .map(this::toPublicResponseDTO)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Busca pública por ID: retorna apenas petshops APROVADOS, sem dados sensíveis.
+     */
+    @Transactional(readOnly = true)
+    public PetshopPublicResponseDTO buscarPorIdPublico(Long id) {
+        Petshop petshop = petshopRepository.findById(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Petshop não encontrado com o ID: " + id));
+        if (petshop.getStatusAprovacao() != StatusAprovacao.APROVADO) {
+            throw new ResourceNotFoundException("Petshop não encontrado com o ID: " + id);
+        }
+        return toPublicResponseDTO(petshop);
     }
 
     /**
@@ -192,6 +205,18 @@ public class PetshopService {
                 .website(petshop.getWebsite())
                 .valorMinimoFreteGratis(petshop.getValorMinimoFreteGratis())
                 .statusAprovacao(petshop.getStatusAprovacao())
+                .build();
+    }
+
+    private PetshopPublicResponseDTO toPublicResponseDTO(Petshop petshop) {
+        return PetshopPublicResponseDTO.builder()
+                .id(petshop.getId())
+                .nomeFantasia(petshop.getNomeFantasia())
+                .telefoneContato(petshop.getTelefoneContato())
+                .endereco(petshop.getEndereco())
+                .descricao(petshop.getDescricao())
+                .website(petshop.getWebsite())
+                .valorMinimoFreteGratis(petshop.getValorMinimoFreteGratis())
                 .build();
     }
 }

--- a/backend/src/test/java/com/Mybuddy/Myb/Controller/OngControllerTest.java
+++ b/backend/src/test/java/com/Mybuddy/Myb/Controller/OngControllerTest.java
@@ -1,18 +1,20 @@
 package com.Mybuddy.Myb.Controller;
 
 import com.Mybuddy.Myb.Config.SecurityConfig;
+import com.Mybuddy.Myb.DTO.PetResponse;
 import com.Mybuddy.Myb.Model.EventoOng;
 import com.Mybuddy.Myb.Model.InteresseAdocao;
 import com.Mybuddy.Myb.Model.Organizacao;
 import com.Mybuddy.Myb.Model.Pet;
+import com.Mybuddy.Myb.Model.StatusAdocao;
 import com.Mybuddy.Myb.Model.Usuario;
 import com.Mybuddy.Myb.Security.ERole;
 import com.Mybuddy.Myb.Security.Role;
 import com.Mybuddy.Myb.Security.JwtAuthConverter;
 import com.Mybuddy.Myb.Service.KeycloakUserSyncService;
+import com.Mybuddy.Myb.Service.PetService;
 import com.Mybuddy.Myb.Repository.mongo.EventoOngRepository;
 import com.Mybuddy.Myb.Repository.mongo.InteresseAdocaoRepository;
-import com.Mybuddy.Myb.Repository.mongo.PetRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,7 +48,7 @@ class OngControllerTest {
     private EventoOngRepository eventoOngRepository;
 
     @MockitoBean
-    private PetRepository petRepository;
+    private PetService petService;
 
     @MockitoBean
     private KeycloakUserSyncService keycloakUserSyncService;
@@ -54,6 +56,7 @@ class OngControllerTest {
     private Usuario adminUser;
     private Usuario ongUser;
     private Pet pet;
+    private PetResponse petResponse;
     private InteresseAdocao interesse;
     private EventoOng evento;
 
@@ -74,6 +77,9 @@ class OngControllerTest {
         pet.setId(100L);
         pet.setNome("Bidu");
         pet.setOrganizacao(org);
+
+        petResponse = new PetResponse(100L, "Bidu", null, null, null, null, null, null, null,
+                List.of(), null, StatusAdocao.DISPONIVEL, "Org", 10L, false, false, false, null, null, null);
 
         interesse = new InteresseAdocao();
         interesse.setId(1000L);
@@ -140,7 +146,7 @@ class OngControllerTest {
     @Test
     void deveRetornarPetsFiltradosParaOng() throws Exception {
         when(keycloakUserSyncService.syncUsuario(any())).thenReturn(ongUser);
-        when(petRepository.findByOrganizacaoId(10L)).thenReturn(List.of(pet));
+        when(petService.buscarPetsPorOrganizacaoId(10L)).thenReturn(List.of(petResponse));
 
         mockMvc.perform(get("/api/ong/pets")
                         .with(jwt().authorities(() -> "ROLE_ONG")))
@@ -151,7 +157,7 @@ class OngControllerTest {
     @Test
     void deveRetornarTodosOsPetsParaAdmin() throws Exception {
         when(keycloakUserSyncService.syncUsuario(any())).thenReturn(adminUser);
-        when(petRepository.findAll()).thenReturn(List.of(pet));
+        when(petService.listarTodosDTO()).thenReturn(List.of(petResponse));
 
         mockMvc.perform(get("/api/ong/pets")
                         .with(jwt().authorities(() -> "ROLE_ADMIN")))

--- a/backend/src/test/java/com/Mybuddy/Myb/Controller/PetshopControllerTest.java
+++ b/backend/src/test/java/com/Mybuddy/Myb/Controller/PetshopControllerTest.java
@@ -94,16 +94,10 @@ class PetshopControllerTest {
     }
 
     @Test
-    void deveRetornar200QuandoBuscarProdutosComUsuarioComum() throws Exception {
-        when(keycloakUserSyncService.syncUsuario(any())).thenReturn(regularUser);
-        when(produtoRepository.findAll()).thenReturn(List.of(produto));
-
+    void deveRetornar403QuandoBuscarProdutosComUsuarioComum() throws Exception {
         mockMvc.perform(get("/api/petshop/produtos")
                         .with(jwt().authorities(() -> "ROLE_ADOTANTE")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].nome").value("Ração Premium"));
-
-        verify(produtoRepository, times(1)).findAll();
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/backend/src/test/java/com/Mybuddy/Myb/Service/PetshopServiceTest.java
+++ b/backend/src/test/java/com/Mybuddy/Myb/Service/PetshopServiceTest.java
@@ -1,5 +1,6 @@
 package com.Mybuddy.Myb.Service;
 
+import com.Mybuddy.Myb.DTO.PetshopPublicResponseDTO;
 import com.Mybuddy.Myb.DTO.PetshopRequestDTO;
 import com.Mybuddy.Myb.DTO.PetshopResponseDTO;
 import com.Mybuddy.Myb.Exception.ConflictException;
@@ -163,10 +164,10 @@ public class PetshopServiceTest {
         Petshop aprovado = Petshop.builder().id(10L).nomeFantasia("Aprovado").statusAprovacao(StatusAprovacao.APROVADO).build();
         when(petshopRepository.findByStatusAprovacao(StatusAprovacao.APROVADO)).thenReturn(List.of(aprovado));
 
-        List<PetshopResponseDTO> lista = petshopService.listarAprovados();
+        List<PetshopPublicResponseDTO> lista = petshopService.listarAprovados();
 
         assertEquals(1, lista.size());
-        assertEquals(StatusAprovacao.APROVADO, lista.get(0).getStatusAprovacao());
+        assertEquals("Aprovado", lista.get(0).getNomeFantasia());
     }
 
     @Test


### PR DESCRIPTION
## Task Jira
- **Card:** [MYB-380](https://mybuddy.atlassian.net/browse/MYB-380)
- **Tipo:** Bug

---
## O que foi feito?
Correção de vazamento de dados e implementação de multi-tenancy no OngController e PetshopController. Usuários não autenticados ou de outras organizações não conseguem mais acessar dados de ONGs e petshops alheios. Adicionados filtros por tenant em todas as queries e removidos dados sensíveis das respostas públicas.

---
## Escopo das mudanças
- [x] `backend` — Java / Spring Boot
- [ ] `frontend` — Angular
- [ ] `mobile` — Flutter
- [ ] `infra` — Docker / CI / configurações

---
## Checklist de Testes
- [x] Testei localmente e o comportamento está conforme esperado
- [x] Cobri os casos de sucesso e os casos de erro
- [x] Não há erros ou warnings novos no console
- [ ] Validei em mais de um ambiente (se aplicável)
- [x] Testes automatizados foram criados ou atualizados (se aplicável)

---
## Checklist de Code